### PR TITLE
[기능 향상] ListDto class에 제네릭 적용 및 type attribute 추가

### DIFF
--- a/src/main/java/com/wiztrip/dto/ListDto.java
+++ b/src/main/java/com/wiztrip/dto/ListDto.java
@@ -1,5 +1,6 @@
 package com.wiztrip.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -7,12 +8,15 @@ import java.util.List;
 
 @Getter
 @Setter
-public class ListDto {
+public class ListDto<T> {
+    @Schema(description = "list의 generic type",example = "~~ResponseDto")
+    String type;
     Integer listSize;
-    List<?> list = new ArrayList<>();
+    List<T> list = new ArrayList<>();
 
-    public ListDto(List<?> list) {
-        this.list = list;
+    public ListDto(List<T> list) {
+        this.type = !list.isEmpty()?list.get(0).getClass().getSimpleName():null;
         this.listSize = list.size();
+        this.list = list;
     }
 }

--- a/src/main/java/com/wiztrip/dto/ListDto.java
+++ b/src/main/java/com/wiztrip/dto/ListDto.java
@@ -11,7 +11,10 @@ import java.util.List;
 public class ListDto<T> {
     @Schema(description = "list의 generic type",example = "~~ResponseDto")
     String type;
+
     Integer listSize;
+
+    @Schema(description = "response data list")
     List<T> list = new ArrayList<>();
 
     public ListDto(List<T> list) {


### PR DESCRIPTION
ListDto class에 제네릭을 적용하고 type을 추가했습니다.

이를 통해 
1. Swagger 에서 response example value를 볼 때 조금 더 자세한 예시를 볼 수 있습니다.
2.  List 안에 어떤 DTO가 들어있는지 확인할 수 있습니다.

![image](https://github.com/Wiz-trip/Wiz-trip-Back/assets/90593322/cacee55b-6d52-43dc-855a-95d7864c7c6c)


PR merge 후 2가지 작업이 필요합니다.

1. Controller의 반환형 변경
 ex) public ResponseEntity<ListDto> methodname() --> public ResponseEntity<ListDto<~~ResponseDto>> methodname()

3. Service의 반환형 변경
 ex) public ListDto<PlanDto.PlanResponseDto> methodname() --> public ListDto<~~ResponseDto> methodname()
       , return new ListDto(~~~) --> return new ListDto<>(~~~)
