### PR TITLE
[기능 구현] 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,14 @@ dependencies {
     //ImageIO에서 webp형식 지원
     implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 
+    //EMAIL
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //REDIS
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.0'
+
+
+
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     //JUnit4 추가

--- a/src/main/java/com/wiztrip/controller/EmailVerificationController.java
+++ b/src/main/java/com/wiztrip/controller/EmailVerificationController.java
@@ -1,0 +1,27 @@
+package com.wiztrip.controller;
+
+import com.wiztrip.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/email-verification")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping
+    public ResponseEntity<?> sendCode(@RequestParam("email") String email) {
+        emailVerificationService.sendCodeToEmail(email);
+        return ResponseEntity.ok().body("발송완료");
+    }
+
+    @GetMapping
+    public ResponseEntity<?> verifyCode(@RequestParam("email") String email, @RequestParam("code") String code) {
+        return ResponseEntity.ok().body(emailVerificationService.verifyCode(email, code));
+    }
+}

--- a/src/main/java/com/wiztrip/controller/EmailVerificationController.java
+++ b/src/main/java/com/wiztrip/controller/EmailVerificationController.java
@@ -1,6 +1,10 @@
 package com.wiztrip.controller;
 
 import com.wiztrip.service.EmailVerificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,14 +18,37 @@ public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
 
+    @Operation(summary = "인증번호 발송",
+            responses = {@ApiResponse(
+                    responseCode = "200",
+                    description = "발송 성공 여부와는 관계 없이 200임.",
+                    content = {
+                            @Content(mediaType = "*/*",
+                                    schema = @Schema(example = "발송완료"))})})
     @PostMapping
-    public ResponseEntity<?> sendCode(@RequestParam("email") String email) {
+    public ResponseEntity<?> sendCode(
+            @Schema(description = "인증번호를 보낼 email 주소", example = "example@example.com")
+            @RequestParam("email")
+            String email) {
         emailVerificationService.sendCodeToEmail(email);
         return ResponseEntity.ok().body("발송완료");
     }
 
+    @Operation(summary = "인증번호 인증",
+            responses = {@ApiResponse(
+                    responseCode = "200",
+                    description = "인증번호가 올바르면 true, 아니면 false 리턴",
+                    content = {
+                            @Content(mediaType = "*/*",
+                                    schema = @Schema(example = "true"))})})
     @GetMapping
-    public ResponseEntity<?> verifyCode(@RequestParam("email") String email, @RequestParam("code") String code) {
+    public ResponseEntity<?> verifyCode(
+            @Schema(description = "인증번호를 보낸 email 주소", example = "example@example.com")
+            @RequestParam("email")
+            String email,
+            @Schema(description = "받은 인증번호", example = "123456")
+            @RequestParam("code")
+            String code) {
         return ResponseEntity.ok().body(emailVerificationService.verifyCode(email, code));
     }
 }

--- a/src/main/java/com/wiztrip/repository/UserRepository.java
+++ b/src/main/java/com/wiztrip/repository/UserRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<UserEntity,Long> {
 
     UserEntity findByUsername(String username);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/wiztrip/service/EmailVerificationService.java
+++ b/src/main/java/com/wiztrip/service/EmailVerificationService.java
@@ -1,0 +1,58 @@
+package com.wiztrip.service;
+
+
+import com.wiztrip.tool.email.EmailTool;
+import com.wiztrip.tool.redis.RedisTool;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final RedisTool redisTool;
+
+    private final EmailTool emailTool;
+    private static final String AUTH_CODE_PREFIX = "AuthCode ";
+
+    @Value("${spring.mail.auth-code-expiration-millis}")
+    private long authCodeExpirationMillis;
+
+    public void sendCodeToEmail(String toEmail) {
+        String title = "WIZ-TRIP 이메일 인증 번호";
+        String authCode = this.createCode();
+        // 이메일 인증 요청 시 인증 번호 Redis에 저장
+        redisTool.setValues(AUTH_CODE_PREFIX + toEmail,
+                authCode, Duration.ofMillis(authCodeExpirationMillis));
+        emailTool.sendEmail(toEmail, title, authCode);
+    }
+
+
+    public boolean verifyCode(String email, String authCode) {
+        String redisAuthCode = redisTool.getValues(AUTH_CODE_PREFIX + email);
+
+        return redisTool.checkExistsValue(redisAuthCode) && redisAuthCode.equals(authCode);
+    }
+
+    private String createCode() {
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < 6; i++) {
+                builder.append(random.nextInt(10));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            System.out.println("create code 오류");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/wiztrip/service/EmailVerificationService.java
+++ b/src/main/java/com/wiztrip/service/EmailVerificationService.java
@@ -1,6 +1,9 @@
 package com.wiztrip.service;
 
 
+import com.wiztrip.exception.CustomException;
+import com.wiztrip.exception.ErrorCode;
+import com.wiztrip.repository.UserRepository;
 import com.wiztrip.tool.email.EmailTool;
 import com.wiztrip.tool.redis.RedisTool;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,8 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class EmailVerificationService {
 
+    private final UserRepository userRepository;
+
     private final RedisTool redisTool;
 
     private final EmailTool emailTool;
@@ -27,6 +32,10 @@ public class EmailVerificationService {
     private long authCodeExpirationMillis;
 
     public void sendCodeToEmail(String toEmail) {
+        //이메일 중복 검사
+        if(userRepository.existsByEmail(toEmail)) throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+
+        //인증코드 생성, 저장 및 이메일 전송
         String title = "WIZ-TRIP 이메일 인증 번호";
         String authCode = this.createCode();
         // 이메일 인증 요청 시 인증 번호 Redis에 저장

--- a/src/main/java/com/wiztrip/tool/email/EmailProperties.java
+++ b/src/main/java/com/wiztrip/tool/email/EmailProperties.java
@@ -1,0 +1,68 @@
+package com.wiztrip.tool.email;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailProperties {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/wiztrip/tool/email/EmailTool.java
+++ b/src/main/java/com/wiztrip/tool/email/EmailTool.java
@@ -1,0 +1,45 @@
+package com.wiztrip.tool.email;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class EmailTool {
+
+    private final JavaMailSender javaMailSender;
+
+    //무분별한 스레드 생성을 막기 위한 스레드 풀
+    private final ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    public void sendEmail(String email, String title, String text) {
+        SimpleMailMessage emailForm = createEmailForm(email, title, text);
+        executorService.submit(() -> {
+            try {
+                javaMailSender.send(emailForm);
+                log.info("이메일");
+            } catch (Exception e) {
+                log.error("이메일 발송 오류");
+            }
+        });
+    }
+
+    // 발신할 이메일 데이터 세팅
+    private SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+}

--- a/src/main/java/com/wiztrip/tool/file/Base64Dto.java
+++ b/src/main/java/com/wiztrip/tool/file/Base64Dto.java
@@ -1,4 +1,4 @@
-package com.wiztrip.tool;
+package com.wiztrip.tool.file;
 
 import lombok.*;
 

--- a/src/main/java/com/wiztrip/tool/file/Base64Tool.java
+++ b/src/main/java/com/wiztrip/tool/file/Base64Tool.java
@@ -1,4 +1,4 @@
-package com.wiztrip.tool;
+package com.wiztrip.tool.file;
 
 import org.apache.commons.net.util.Base64;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/wiztrip/tool/file/FtpTestController.java
+++ b/src/main/java/com/wiztrip/tool/file/FtpTestController.java
@@ -1,4 +1,4 @@
-package com.wiztrip.tool;
+package com.wiztrip.tool.file;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/wiztrip/tool/file/FtpTool.java
+++ b/src/main/java/com/wiztrip/tool/file/FtpTool.java
@@ -1,4 +1,4 @@
-package com.wiztrip.tool;
+package com.wiztrip.tool.file;
 
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;

--- a/src/main/java/com/wiztrip/tool/file/WebpConvertTool.java
+++ b/src/main/java/com/wiztrip/tool/file/WebpConvertTool.java
@@ -1,4 +1,4 @@
-package com.wiztrip.tool;
+package com.wiztrip.tool.file;
 
 import org.apache.tomcat.util.http.fileupload.ByteArrayOutputStream;
 import org.imgscalr.Scalr;

--- a/src/main/java/com/wiztrip/tool/file/WebpTestController.java
+++ b/src/main/java/com/wiztrip/tool/file/WebpTestController.java
@@ -1,4 +1,4 @@
-package com.wiztrip.tool;
+package com.wiztrip.tool.file;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/wiztrip/tool/redis/RedisConfig.java
+++ b/src/main/java/com/wiztrip/tool/redis/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.wiztrip.tool.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    // RedisProperties로 yaml에 저장한 host, post를 연결
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // serializer 설정으로 redis-cli를 통해 직접 데이터를 조회할 수 있도록 설정
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/wiztrip/tool/redis/RedisTool.java
+++ b/src/main/java/com/wiztrip/tool/redis/RedisTool.java
@@ -1,0 +1,68 @@
+package com.wiztrip.tool.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class RedisTool {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValues(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}


### PR DESCRIPTION
이메일 인증 구현 완료했습니다.

/email-verification 엔드포인트를 통해 이메일 인증을 사용할 수 있습니다.

인증번호 저장에 redis를 사용했기 때문에 redis 설치가 필요합니다.
mac : https://redis.io/docs/install/install-redis/install-redis-on-mac-os/
windows: https://github.com/microsoftarchive/redis

