### PR TITLE
[기능 향상] 예외처리 수정

### DIFF
--- a/src/main/java/com/wiztrip/exception/ErrorCode.java
+++ b/src/main/java/com/wiztrip/exception/ErrorCode.java
@@ -11,17 +11,41 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorCode {
 
     // 400 BAD_REQUEST: 잘못된 요청
-    INVALID_PARAMETER(BAD_REQUEST, "입력 값을 확인해주세요."),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰이 유효하지 않습니다"),
+    MISMATCH_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰의 유저 정보가 일치하지 않습니다"),
+    WRONG_USERNAME(BAD_REQUEST, "아이디가 잘못 입력되었습니다."),
+    WRONG_PASSWORD(UNAUTHORIZED, "비밀번호가 잘못 입력되었습니다."),
 
     // 401 UNAUTHORIZED: 인증되지 않은 사용자
+    INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다"),
     UNAUTHORIZED_MEMBER(UNAUTHORIZED, "존재하지 않는 회원입니다."),
 
-    // 404 NOT_FOUND: 잘못된 리소스 접근
-    MEMBER_NOT_FOUND(NOT_FOUND, "해당 회원 정보를 찾을 수 없습니다."),
-    LANDMARK_NOT_EXIST(NOT_FOUND, "해당 여행지 정보를 찾을 수 없습니다."),
+    // 403 FORBIDDEN: 접근 권한이 없는 사용자
+    FORBIDDEN_UPDATE_TRIP_USER(FORBIDDEN, "전체 여행 계획 수정 권한이 없는 사용자입니다."),
+    FORBIDDEN_DELETE_TRIP_USER(FORBIDDEN, "전체 여행 계획 삭제 권한이 없는 사용자입니다."),
+    FORBIDDEN_UPDATE_PLAN_USER(FORBIDDEN, "세부 여행 계획 수정 권한이 없는 사용자입니다."),
+    FORBIDDEN_DELETE_PLAN_USER(FORBIDDEN, "세부 여행 계획 삭제 권한이 없는 사용자입니다."),
+    FORBIDDEN_UPDATE_MEMO_USER(FORBIDDEN, "메모 수정 권한이 없는 사용자입니다."),
+    FORBIDDEN_DELETE_MEMO_USER(FORBIDDEN, "메모 삭제 권한이 없는 사용자입니다."),
+    FORBIDDEN_UPDATE_REVIEW_USER(FORBIDDEN, "후기글 수정 권한이 없는 사용자입니다."),
+    FORBIDDEN_DELETE_REVIEW_USER(FORBIDDEN, "후기글 삭제 권한이 없는 사용자입니다."),
 
-    // 409 CONFLICT: 중복된 리소스
-    DUPLICATE_EMAIL(CONFLICT, "해당 이메일은 이미 존재합니다."),
+    // 404 NOT_FOUND: 잘못된 리소스 접근
+    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
+    MEMBER_NOT_FOUND(NOT_FOUND, "해당 회원 정보를 찾을 수 없습니다."),
+    LANDMARK_NOT_FOUND(NOT_FOUND, "해당 여행지 정보를 찾을 수 없습니다."),
+    TRIP_NOT_FOUND(NOT_FOUND, "해당 전체 여행 계획을 찾을 수 없습니다."),
+    PLAN_NOT_FOUND(NOT_FOUND, "해당 세부 여행 계획을 찾을 수 없습니다."),
+    MEMO_NOT_FOUND(NOT_FOUND, "해당 메모를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(NOT_FOUND, "해당 후기글을 찾을 수 없습니다."),
+    LANDMARK_NOT_EXIST(NOT_FOUND, "저장된 여행지 정보가 아직 없습니다."),
+    TRIP_NOT_EXIST(NOT_FOUND,"예정된 전체 여행 계획이 아직 없습니다."),
+    PLAN_NOT_EXIST(NOT_FOUND, "작성된 세부 여행 계획이 아직 없습니다."),
+    MEMO_NOT_EXIST(NOT_FOUND, "작성된 메모가 아직 없습니다."),
+    REVIEW_NOT_EXIST(NOT_FOUND,"작성된 후기글이 아직 없습니다."),
+
+    // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)
+    DUPLICATE_EMAIL(CONFLICT, "이미 존재하는 이메일입니다."),
 
     // 500 INTERNAL SERVER ERROR
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "내부 서버 에러입니다.");

--- a/src/main/java/com/wiztrip/exception/ErrorCode.java
+++ b/src/main/java/com/wiztrip/exception/ErrorCode.java
@@ -29,6 +29,10 @@ public enum ErrorCode {
     FORBIDDEN_DELETE_MEMO_USER(FORBIDDEN, "메모 삭제 권한이 없는 사용자입니다."),
     FORBIDDEN_UPDATE_REVIEW_USER(FORBIDDEN, "후기글 수정 권한이 없는 사용자입니다."),
     FORBIDDEN_DELETE_REVIEW_USER(FORBIDDEN, "후기글 삭제 권한이 없는 사용자입니다."),
+    NOT_IN_TRIP_MEMO(FORBIDDEN, "해당 전체 여행 계획에 속한 메모가 아닙니다."),
+    NOT_IN_TRIP_PLAN(FORBIDDEN, "해당 전체 여행 계획에 속한 세부 여행 계획이 아닙니다."),
+    NOT_IN_TRIP_REVIEW(FORBIDDEN, "해당 전체 여행 계획에 속한 후기글이 아닙니다."),
+
 
     // 404 NOT_FOUND: 잘못된 리소스 접근
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
@@ -46,6 +50,8 @@ public enum ErrorCode {
 
     // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)
     DUPLICATE_EMAIL(CONFLICT, "이미 존재하는 이메일입니다."),
+    DUPLICATE_LANDMARK_LIKE(CONFLICT, "사용자가 이미 좋아요에 추가한 여행지입니다."),
+    NO_LANDMARK_LIKE_EXIST(CONFLICT, "사용자가 좋아요에 추가하지 않은 여행지입니다."),
 
     // 500 INTERNAL SERVER ERROR
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "내부 서버 에러입니다.");

--- a/src/main/java/com/wiztrip/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/wiztrip/exception/GlobalExceptionAdvice.java
@@ -90,7 +90,7 @@ public class GlobalExceptionAdvice {
 
     }
 
-    // 예상하지 못한 모든 예외를 처리 (
+    // 예상하지 못한 모든 예외를 처리
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {

--- a/src/main/java/com/wiztrip/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/wiztrip/exception/GlobalExceptionAdvice.java
@@ -3,7 +3,10 @@ package com.wiztrip.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,104 +17,110 @@ import java.time.LocalDateTime;
 @RestControllerAdvice
 public class GlobalExceptionAdvice {
 
-    // CustomException
+    // CustomException: Error Code에 정의된 비즈니스 로직 오류
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
 
         ErrorCode errorCode = e.getErrorCode();
 
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                errorCode.getHttpStatus().value(),
-                errorCode.getHttpStatus().getReasonPhrase(),
-                errorCode.getMessage()
-        );
+        return getErrorResponse(e, errorCode.getHttpStatus());
 
-        log.error("Exception: {} time: {} ErrorCode: {} Message: {} Detail: {}",
-                e.getClass().getSimpleName(), LocalDateTime.now(), errorCode.getMessage(), e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
     }
 
-    // RuntimeException
-    @ExceptionHandler(RuntimeException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
-
-        ErrorCode errorCode = ErrorCode.SERVER_ERROR;
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                errorCode.getHttpStatus().value(),
-                errorCode.getHttpStatus().getReasonPhrase(),
-                errorCode.getMessage()
-        );
-
-        log.error("Exception: {} time: {} ErrorCode: {} Message: {} Detail: {}",
-                e.getClass().getSimpleName(), LocalDateTime.now(), errorCode.getMessage(), e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
-    }
-
-    // NullPointerException: 실제 값이 아닌 null을 가지고 있는 변수 혹은 객체를 호출할 경우
-    @ExceptionHandler(NullPointerException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
-
-        ErrorCode errorCode = ErrorCode.SERVER_ERROR;
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                errorCode.getHttpStatus().value(),
-                errorCode.getHttpStatus().getReasonPhrase(),
-                errorCode.getMessage()
-        );
-
-        log.error("Exception: {} time: {} ErrorCode: {} Message: {} Detail: {}",
-                e.getClass().getSimpleName(), LocalDateTime.now(), errorCode.getMessage(), e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
-    }
-
-    // IllegalArgumentException: 사용자가 값을 잘못 입력한 경우
+    /*
+        BAD_REQUEST (400)
+        IllegalArgumentException: 사용자가 값을 잘못 입력한 경우
+        MethodArgumentNotValidException: 전달된 값이 유효하지 않은 경우
+        HttpMessageNotReadableException: 잘못된 형식으로 요청할 경우
+        MissingServletRequestParameterException: 필수 요청 매개변수가 누락된 경우
+    */
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
 
-        ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
 
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                errorCode.getHttpStatus().value(),
-                errorCode.getHttpStatus().getReasonPhrase(),
-                errorCode.getMessage()
-        );
-
-        log.error("Exception: {} time: {} ErrorCode: {} Message: {} Detail: {}",
-                e.getClass().getSimpleName(), LocalDateTime.now(), errorCode.getMessage(), e.getMessage());
-
-        return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
     }
 
-    // MethodArgumentNotValidException: 전달된 값이 유효하지 않은 경우
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
 
-        ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
 
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                errorCode.getHttpStatus().value(),
-                errorCode.getHttpStatus().getReasonPhrase(),
-                errorCode.getMessage()
-        );
+    }
 
-        log.error("Exception: {} time: {} ErrorCode: {} Message: {} Detail: {}",
-                e.getClass().getSimpleName(), LocalDateTime.now(), errorCode.getMessage(), e.getMessage());
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
 
-        return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
+
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
+
+    }
+
+    /*
+        METHOD_NOT_ALLOWED (405)
+        HttpRequestMethodNotSupportedException: 잘못된 Http Method를 가지고 요청할 경우
+    */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+
+        return getErrorResponse(e, HttpStatus.METHOD_NOT_ALLOWED);
+
+    }
+
+    /*
+        INTERNAL_SERVER_ERROR (500)
+        RuntimeException
+    */
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+
+        return getErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+
+    }
+
+    // 예상하지 못한 모든 예외를 처리 (
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+
+        return getErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+
     }
 
     // 추후 자주 발생하는 오류에 대해 추가
+
+    // 공통 로직
+    private ResponseEntity<ErrorResponse> getErrorResponse(Exception e, HttpStatus httpStatus) {
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                httpStatus.value(),
+                httpStatus.getReasonPhrase(),
+                e.getMessage()
+        );
+
+        logError(e, httpStatus);
+
+        return new ResponseEntity<>(errorResponse, httpStatus);
+
+    }
+
+    private void logError(Exception e, HttpStatus httpStatus) {
+
+        log.error("Exception: {} time: {} ErrorCode: {} Message: {}",
+                e.getClass().getSimpleName(), LocalDateTime.now(), httpStatus.getReasonPhrase(), e.getMessage());
+
+    }
 }


### PR DESCRIPTION
비즈니스 로직에서 발생하는 예외는 ErrorCode에서 정의 후, CustomException에서 처리하게 구현하였고,
시스템 내부에서 발생하는 예외는 예측 가능한 일부의 예외만 GlobalExceptionAdvice에서 정의 후, 해당 예외에서 처리하게 구현하였습니다.
미처 예측하지 못한 예외는 일단 모두 서버 오류로 정의하여 처리되게 구현하였습니다.
자세한 예외는 모두 log를 통해 확인 가능합니다.

또한, 앞선 코드에서 중복된 코드가 많은 것 같아 해당 부분을 수정하였습니다.
ErrorCode는 추후 계속해서 추가하도록 하겠습니다.

추가, 보완할 부분이 있다면 말씀해주세요.