### PR TITLE
[기능 향상] memo 수정

### DIFF
--- a/src/main/java/com/wiztrip/controller/MemoController.java
+++ b/src/main/java/com/wiztrip/controller/MemoController.java
@@ -1,18 +1,21 @@
 package com.wiztrip.controller;
 
-import com.wiztrip.dto.ListDto;
+import com.wiztrip.constant.Category;
 import com.wiztrip.dto.MemoDto;
 import com.wiztrip.service.MemoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Tag(name = "Memo")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("trips/{trip_id}/memos")
+@RequestMapping("trips/{tripId}/memos")
 public class MemoController {
 
     private final MemoService memoService;
@@ -20,32 +23,42 @@ public class MemoController {
     // 메모 생성
     @PostMapping
     @Operation(summary = "Memo 생성",
-            description = "trip_id와 MemoPostDto를 사용해 해당 Trip(전체 여행 계획)에 속한 Memo를 생성합니다.")
-    public ResponseEntity<MemoDto.MemoResponseDto> createMemo(@PathVariable("trip_id") Long tripId, @RequestBody MemoDto.MemoPostDto memoPostDto) {
+            description = "tripId와 MemoPostDto를 사용해 해당 Trip(전체 여행 계획)에 속한 Memo를 생성합니다.")
+    public ResponseEntity<MemoDto.MemoResponseDto> createMemo(@PathVariable("tripId") Long tripId, @RequestBody MemoDto.MemoPostDto memoPostDto) {
         return ResponseEntity.ok().body(memoService.createMemo(tripId, memoPostDto));
     }
 
-    // 메모 조회 (전체 전달)
+    // 메모 조회 (카테고리별)
     @GetMapping
     @Operation(summary = "Memo 조회",
-            description = "trip_id를 사용해 카테고리 상관 없이 해당 Trip(전체 여행 계획)에 작성된 모든 Memo를 전달합니다. ")
-    public ResponseEntity<ListDto<MemoDto.MemoResponseDto>> getMemoAll(@PathVariable("trip_id") Long tripId) {
-        return ResponseEntity.ok().body(memoService.getMemoAll(tripId));
+            description = "tripId를 사용해 해당 Trip(전체 여행 계획)에 작성된 카테고리별 Memo를 전달합니다. " +
+                    "페이징을 사용해 한 페이지에 몇 개의 Memo를 받고 싶은지 설정할 수 있고, 원하는 페이지에 속한 Memo를 확인할 수 있습니다." + "\n" + "\n" +
+            "/trips/{tripId}/memos?category={카테고리명}&pageNum={페이지수}&pageSize={페이지크기}"
+    )
+    public ResponseEntity<Map<String, Object>> getMemoByCategory(
+            @PathVariable("tripId") Long tripId,
+            @RequestParam Category category,
+            @RequestParam(defaultValue = "0") Integer pageNum,
+            @RequestParam(defaultValue = "10") Integer pageSize) {
+
+        PageRequest pageRequest = PageRequest.of(pageNum, pageSize);
+        return ResponseEntity.ok().body(memoService.getMemoByCategory(tripId, category, pageRequest));
     }
 
     // 메모 수정
     @PatchMapping
     @Operation(summary = "Memo 수정",
-            description = "trip_id와 MemoPatchtDto를 사용해 해당 Memo를 삭제합니다.")
-    public ResponseEntity<MemoDto.MemoResponseDto> updateMemo(@PathVariable("trip_id") Long tripId, @RequestBody MemoDto.MemoPatchDto memoPatchDto) {
+            description = "tripId와 MemoPatchtDto를 사용해 해당 Memo를 삭제합니다.")
+    public ResponseEntity<MemoDto.MemoResponseDto> updateMemo(@PathVariable("tripId") Long tripId, @RequestBody MemoDto.MemoPatchDto memoPatchDto) {
         return ResponseEntity.ok().body(memoService.updateMemo(tripId, memoPatchDto));
     }
 
     // 메모 삭제
     @DeleteMapping
     @Operation(summary = "Memo 삭제",
-            description = "trip_id와 memo_id를 사용해 해당 Memo를 삭제합니다.")
-    public ResponseEntity<String> deleteMemo(@PathVariable("trip_id") Long tripId, @RequestParam("memo_id") Long memoId) {
+            description = "tripId와 memoId를 사용해 해당 Memo를 삭제합니다." + "\n" + "\n" +
+                    "/trips/{tripId}/memos?memo_id={memoId}")
+    public ResponseEntity<String> deleteMemo(@PathVariable("tripId") Long tripId, @RequestParam("memoId") Long memoId) {
         return ResponseEntity.ok().body(memoService.deleteMemo(tripId, memoId));
     }
 }

--- a/src/main/java/com/wiztrip/controller/MemoController.java
+++ b/src/main/java/com/wiztrip/controller/MemoController.java
@@ -6,11 +6,11 @@ import com.wiztrip.service.MemoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @Tag(name = "Memo")
 @RestController
@@ -31,17 +31,23 @@ public class MemoController {
     // 메모 조회 (카테고리별)
     @GetMapping
     @Operation(summary = "Memo 조회",
-            description = "tripId를 사용해 해당 Trip(전체 여행 계획)에 작성된 카테고리별 Memo를 전달합니다. " +
-                    "페이징을 사용해 한 페이지에 몇 개의 Memo를 받고 싶은지 설정할 수 있고, 원하는 페이지에 속한 Memo를 확인할 수 있습니다." + "\n" + "\n" +
-            "/trips/{tripId}/memos?category={카테고리명}&pageNum={페이지수}&pageSize={페이지크기}"
+            description = """
+                tripId를 사용해 해당 Trip(전체 여행 계획)에 작성된 카테고리별 Memo를 최신순으로 전달합니다.
+                페이징을 사용해 한 페이지에 몇 개의 Memo를 받고 싶은지 설정할 수 있고, 원하는 페이지에 속한 Memo를 확인할 수 있습니다.
+                
+                /trips/{tripId}/memos?category={카테고리명}&pageNum={페이지수}&pageSize={페이지크기}
+                """
     )
-    public ResponseEntity<Map<String, Object>> getMemoByCategory(
+    public ResponseEntity<Page<MemoDto.MemoResponseDto>> getMemoByCategory(
             @PathVariable("tripId") Long tripId,
             @RequestParam Category category,
             @RequestParam(defaultValue = "0") Integer pageNum,
             @RequestParam(defaultValue = "10") Integer pageSize) {
 
-        PageRequest pageRequest = PageRequest.of(pageNum, pageSize);
+        // 정렬 기준 (최신순)
+        Sort sort = Sort.by(Sort.Direction.DESC, "createAt");
+
+        PageRequest pageRequest = PageRequest.of(pageNum, pageSize, sort);
         return ResponseEntity.ok().body(memoService.getMemoByCategory(tripId, category, pageRequest));
     }
 
@@ -56,8 +62,11 @@ public class MemoController {
     // 메모 삭제
     @DeleteMapping
     @Operation(summary = "Memo 삭제",
-            description = "tripId와 memoId를 사용해 해당 Memo를 삭제합니다." + "\n" + "\n" +
-                    "/trips/{tripId}/memos?memo_id={memoId}")
+            description = """
+                tripId와 memoId를 사용해 해당 Memo를 삭제합니다.
+                
+                /trips/{tripId}/memos?memo_id={memoId}
+                """)
     public ResponseEntity<String> deleteMemo(@PathVariable("tripId") Long tripId, @RequestParam("memoId") Long memoId) {
         return ResponseEntity.ok().body(memoService.deleteMemo(tripId, memoId));
     }

--- a/src/main/java/com/wiztrip/domain/MemoEntity.java
+++ b/src/main/java/com/wiztrip/domain/MemoEntity.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 
 @Entity
 @Getter  @Setter
-public class MemoEntity {
+public class MemoEntity extends TimeStamp{
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/wiztrip/mapstruct/MemoMapper.java
+++ b/src/main/java/com/wiztrip/mapstruct/MemoMapper.java
@@ -3,6 +3,8 @@ package com.wiztrip.mapstruct;
 import com.wiztrip.domain.MemoEntity;
 import com.wiztrip.domain.TripEntity;
 import com.wiztrip.dto.MemoDto;
+import com.wiztrip.exception.CustomException;
+import com.wiztrip.exception.ErrorCode;
 import com.wiztrip.repository.MemoRepository;
 import com.wiztrip.repository.TripRepository;
 import org.mapstruct.*;
@@ -49,6 +51,7 @@ public abstract class MemoMapper {
     @Named("tripIdToTripEntity")
     // TRIP_NOT_FOUND
     TripEntity tripIdToTripEntity(Long tripId) {
-        return tripRepository.findById(tripId).orElseThrow();
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRIP_NOT_FOUND));
     }
 }

--- a/src/main/java/com/wiztrip/mapstruct/MemoMapper.java
+++ b/src/main/java/com/wiztrip/mapstruct/MemoMapper.java
@@ -25,6 +25,8 @@ public abstract class MemoMapper {
 
     @Mappings({
             @Mapping(target = "id", ignore = true),
+            @Mapping(target = "createAt", ignore = true),
+            @Mapping(target = "modifiedAt",ignore = true),
             @Mapping(target = "trip", source = "tripId", qualifiedByName = "tripIdToTripEntity")
     })
     public abstract MemoEntity toEntity(MemoDto.MemoPostDto memoPostDto, Long tripId);
@@ -38,11 +40,14 @@ public abstract class MemoMapper {
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mappings({
             @Mapping(target = "id", ignore = true),
+            @Mapping(target = "createAt", ignore = true),
+            @Mapping(target = "modifiedAt",ignore = true),
             @Mapping(target = "trip", ignore = true)
     })
     public abstract void updateFromPatchDto(MemoDto.MemoPatchDto memoPatchDto, @MappingTarget MemoEntity memo);
 
     @Named("tripIdToTripEntity")
+    // TRIP_NOT_FOUND
     TripEntity tripIdToTripEntity(Long tripId) {
         return tripRepository.findById(tripId).orElseThrow();
     }

--- a/src/main/java/com/wiztrip/repository/MemoRepository.java
+++ b/src/main/java/com/wiztrip/repository/MemoRepository.java
@@ -1,6 +1,9 @@
 package com.wiztrip.repository;
 
+import com.wiztrip.constant.Category;
 import com.wiztrip.domain.MemoEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +11,5 @@ import java.util.List;
 
 @Repository
 public interface MemoRepository extends JpaRepository<MemoEntity, Long> {
-    List<MemoEntity> findAllByTripId(Long tripId);
+    Page<MemoEntity> findAllByTripIdAndCategory(Long tripId, Category category, PageRequest pageRequest);
 }

--- a/src/main/java/com/wiztrip/service/MemoService.java
+++ b/src/main/java/com/wiztrip/service/MemoService.java
@@ -2,7 +2,6 @@ package com.wiztrip.service;
 
 import com.wiztrip.constant.Category;
 import com.wiztrip.domain.MemoEntity;
-import com.wiztrip.dto.ListDto;
 import com.wiztrip.dto.MemoDto;
 import com.wiztrip.exception.CustomException;
 import com.wiztrip.exception.ErrorCode;
@@ -34,7 +33,6 @@ public class MemoService {
         return memoMapper.toResponseDto(memoRepository.save(memoMapper.toEntity(memoPostDto, tripId)));
     }
 
-    // 원하는 데이터 담아서 변환해준 후, ListDto를 통해 리스트화 필요
     public Map<String, Object> getMemoByCategory(Long tripId, Category category, PageRequest pageRequest) {
         Page<MemoEntity> memoPage = memoRepository.findAllByTripIdAndCategory(tripId, category, pageRequest);
 

--- a/src/main/java/com/wiztrip/service/MemoService.java
+++ b/src/main/java/com/wiztrip/service/MemoService.java
@@ -14,10 +14,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -33,22 +29,13 @@ public class MemoService {
         return memoMapper.toResponseDto(memoRepository.save(memoMapper.toEntity(memoPostDto, tripId)));
     }
 
-    public Map<String, Object> getMemoByCategory(Long tripId, Category category, PageRequest pageRequest) {
+    public Page<MemoDto.MemoResponseDto> getMemoByCategory(Long tripId, Category category, PageRequest pageRequest) {
         Page<MemoEntity> memoPage = memoRepository.findAllByTripIdAndCategory(tripId, category, pageRequest);
 
-        List<MemoDto.MemoResponseDto> memoList = memoPage.getContent().stream()
-                .map(o -> {
-                    checkValid(o, tripId);
-                    return memoMapper.toResponseDto(o);
-                })
-                .toList();
-
-        Map<String, Object> memoResponse = new HashMap<>();
-        memoResponse.put("totalElement", memoPage.getTotalElements());
-        memoResponse.put("totalPage", memoPage.getTotalPages());
-        memoResponse.put("list", memoList);
-
-        return memoResponse;
+        return memoPage.map(o -> {
+            checkValid(o, tripId);
+            return memoMapper.toResponseDto(o);
+        });
     }
 
     @Transactional


### PR DESCRIPTION
memo 내의 페이징 기능을 추가하며, 본래 전체 memo를 response했던 memo 조회 부분을 query string을 사용하여 카테고리별로 response하게 수정하였습니다. 

페이징 단위로 줄 경우, 클라이언트 측에서 이를 분류하는 것이 적합하지 않는다고 생각하여 이렇게 수정했는데 혹시 다른 의견이 있다면 알려주세요!