### PR TITLE
kakao 로그인(access token)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,9 @@ dependencies {
 
     //oAuth2
 //    implementation 'com.google.code.gson:gson:2.8.7'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // kakao
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     //FTP
     implementation 'commons-net:commons-net:3.9.0'

--- a/src/main/java/com/wiztrip/config/spring_security/auth/OAuthToken.java
+++ b/src/main/java/com/wiztrip/config/spring_security/auth/OAuthToken.java
@@ -1,0 +1,14 @@
+package com.wiztrip.config.spring_security.auth;
+
+
+import lombok.Data;
+
+@Data
+public class OAuthToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/wiztrip/config/spring_security/jwt/TokenUtils.java
+++ b/src/main/java/com/wiztrip/config/spring_security/jwt/TokenUtils.java
@@ -16,6 +16,8 @@ import java.util.Map;
 public class TokenUtils {
 
     private final PrincipalDetailsService principalDetailsService;
+   // public static final String AUTHORIZATION_HEADER = "Authorization";
+
 
     public String createToken(PrincipalDetails principalDetails, long expirationTime, String secret) {
         return JWT.create()

--- a/src/main/java/com/wiztrip/controller/UserController.java
+++ b/src/main/java/com/wiztrip/controller/UserController.java
@@ -1,15 +1,16 @@
 package com.wiztrip.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.wiztrip.config.spring_security.jwt.TokenUtils;
 import com.wiztrip.dto.UserDto;
 import com.wiztrip.dto.UserRegisterDto;
 import com.wiztrip.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final TokenUtils tokenUtils;
 
     // 회원정보 조회
     @Operation(summary = "회원정보 조회",description = "userId 를 사용하여 회원정보를 조회합니다")
@@ -56,6 +58,5 @@ public class UserController {
         userService.createUser(registrationDto);
         return ResponseEntity.ok("회원가입이 성공적으로 완료");
     }
-
 
 }

--- a/src/main/java/com/wiztrip/controller/kakaoController.java
+++ b/src/main/java/com/wiztrip/controller/kakaoController.java
@@ -2,11 +2,8 @@ package com.wiztrip.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wiztrip.config.spring_security.auth.OAuthToken;
-import com.wiztrip.dto.LoginKakaoDto;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -63,38 +60,32 @@ public class kakaoController {
         }
 
         System.out.println("카카오 엑세스 토큰 :  " + oAuthToken.getAccess_token());
+        System.out.println("코드값 : "+ code);
 
-        return response.getBody();
+       // return response.getBody();
+        //return "카카오 코드 인증값 : " +code;
 
-//        RestTemplate rt2 = new RestTemplate();
-//
-//        // HttpHeaders 오브젝트 생성
-//        HttpHeaders headers2 = new HttpHeaders();
-//        headers2.add("Authorization","Bearer"+oAuthToken.getAccess_token() );
-//        headers2.add("Content-type","application/x-www-form-urlencoded;charset=utf-8");
-//
-//
-//        // HttpHeader 와 HttpBody 를 하나의 오브젝트에 담기
-//        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest2 =
-//                new HttpEntity<>(headers2);
-//
-//        // Http 요청하기 - POST 방식 - response 변수의 응답을 받음
-//        ResponseEntity<String> response2 = rt2.exchange(
-//                "https://kapi.kakao.com/v2/user/me",
-//                HttpMethod.POST,
-//                kakaoProfileRequest2,
-//                String.class
-//        );
-//
-//        String responseBody = response2.getBody();
-//        ObjectMapper objectMapper2 = new ObjectMapper();
-//        JsonNode jsonNode = objectMapper2.readTree(responseBody);
-//
-//        String nickname = RandomStringUtils.random(15,true,true);
-//        String email = jsonNode.get("kakao_account").get("email").asText();
-//
-//
-//        return new LoginKakaoDto(email,nickname);
+        RestTemplate rt2 = new RestTemplate();
+
+        // HttpHeaders 오브젝트 생성
+        HttpHeaders headers2 = new HttpHeaders();
+        headers2.add("Authorization","Bearer "+oAuthToken.getAccess_token() );
+        headers2.add("Content-type","application/x-www-form-urlencoded;charset=utf-8");
+
+
+        // HttpHeader 와 HttpBody 를 하나의 오브젝트에 담기
+        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest2 =
+                new HttpEntity<>(headers2);
+
+        // Http 요청하기 - POST 방식 - response 변수의 응답을 받음
+        ResponseEntity<String> response2 = rt2.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoProfileRequest2,
+                String.class
+        );
+
+        return response2.getBody();
 
     }
 }

--- a/src/main/java/com/wiztrip/controller/kakaoController.java
+++ b/src/main/java/com/wiztrip/controller/kakaoController.java
@@ -1,0 +1,103 @@
+package com.wiztrip.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wiztrip.config.spring_security.auth.OAuthToken;
+import com.wiztrip.dto.LoginKakaoDto;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+
+
+
+@Controller
+public class kakaoController {
+
+    @GetMapping("/auth/kakao/callback")
+    public @ResponseBody String kakaoCallback(String code) throws JsonProcessingException {
+
+        RestTemplate rt = new RestTemplate();
+
+        // HttpHeaders 오브젝트 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HttpBody 오브젝트 생성
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", "c2b3cda0315bd5e42a85ba7cacb0fa43");
+        params.add("redirect_uri", "http://localhost:8080/auth/kakao/callback");
+        params.add("client_secret", "OeA1B2bnoMUPfFZJJI8izZLlpWZix5Bb");
+        params.add("code", code);
+
+        // HttpHeader 와 HttpBody 를 하나의 오브젝트에 담기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(params, headers);
+
+        // Http 요청하기 - POST 방식 - response 변수의 응답을 받음
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        OAuthToken oAuthToken = null;
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        } catch (JsonMappingException e) {
+            e.printStackTrace();
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("카카오 엑세스 토큰 :  " + oAuthToken.getAccess_token());
+
+        return response.getBody();
+
+//        RestTemplate rt2 = new RestTemplate();
+//
+//        // HttpHeaders 오브젝트 생성
+//        HttpHeaders headers2 = new HttpHeaders();
+//        headers2.add("Authorization","Bearer"+oAuthToken.getAccess_token() );
+//        headers2.add("Content-type","application/x-www-form-urlencoded;charset=utf-8");
+//
+//
+//        // HttpHeader 와 HttpBody 를 하나의 오브젝트에 담기
+//        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest2 =
+//                new HttpEntity<>(headers2);
+//
+//        // Http 요청하기 - POST 방식 - response 변수의 응답을 받음
+//        ResponseEntity<String> response2 = rt2.exchange(
+//                "https://kapi.kakao.com/v2/user/me",
+//                HttpMethod.POST,
+//                kakaoProfileRequest2,
+//                String.class
+//        );
+//
+//        String responseBody = response2.getBody();
+//        ObjectMapper objectMapper2 = new ObjectMapper();
+//        JsonNode jsonNode = objectMapper2.readTree(responseBody);
+//
+//        String nickname = RandomStringUtils.random(15,true,true);
+//        String email = jsonNode.get("kakao_account").get("email").asText();
+//
+//
+//        return new LoginKakaoDto(email,nickname);
+
+    }
+}
+
+
+

--- a/src/main/java/com/wiztrip/controller/kakaoController.java
+++ b/src/main/java/com/wiztrip/controller/kakaoController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wiztrip.config.spring_security.auth.OAuthToken;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +15,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.http.HttpHeaders;
-
+import org.springframework.web.servlet.view.RedirectView;
 
 
 @Controller
 public class kakaoController {
 
+    @Operation(summary = "카카오 로그인",description = "카카오 로그인을 진행합니다.")
     @GetMapping("/auth/kakao/callback")
     public @ResponseBody String kakaoCallback(String code) throws JsonProcessingException {
 

--- a/src/main/java/com/wiztrip/domain/UserEntity.java
+++ b/src/main/java/com/wiztrip/domain/UserEntity.java
@@ -31,4 +31,5 @@ public class UserEntity extends TimeStamp {
     private Image image; //프로필 사진
 
     private String nickname; //회원 닉네임
+
 }

--- a/src/main/java/com/wiztrip/dto/LoginKakaoDto.java
+++ b/src/main/java/com/wiztrip/dto/LoginKakaoDto.java
@@ -1,0 +1,16 @@
+package com.wiztrip.dto;
+
+import lombok.*;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginKakaoDto {
+
+        private String email;
+        private String nickname;
+
+}

--- a/src/main/java/com/wiztrip/repository/UserRepository.java
+++ b/src/main/java/com/wiztrip/repository/UserRepository.java
@@ -11,5 +11,6 @@ public interface UserRepository extends JpaRepository<UserEntity,Long> {
 
     Optional<UserEntity> findByUsername(String username);
 
+
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/wiztrip/service/UserService.java
+++ b/src/main/java/com/wiztrip/service/UserService.java
@@ -84,6 +84,8 @@ public class UserService {
         return userRepository.save(newUser);
     }
 
+
+
 }
 
 


### PR DESCRIPTION
카카오 로그인에 필요한 access token 을 받는데 성공하였고, postman 을 통해 로그인한 사용자의 정보를 받아오는 것을 확인했습니다. 
access token 을 받는다는 것은 블로그(사이트) 에서 카카오 자원 서버를 사용할 수 있는 권한을 가질 수 있음을 의미합니다. 
구현에 목적을 두어서 코드가 아직 정리가 안되었지만 후에 정리하도록 하겠습니다. 서버는 localhost:8080 을 사용하였습니다. 

<postman - 사용자 정보 확인>
1. GET https://kapi.kakao.com/v2/user/me 
2. Header Prefix : Bearer / toke : {access token 값}
