### PR TITLE
회원가입시 닉네임 중복 처리 구현

### DIFF
--- a/src/main/java/com/wiztrip/config/OpenApiConfig.java
+++ b/src/main/java/com/wiztrip/config/OpenApiConfig.java
@@ -9,6 +9,8 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Set;
+
 /**
  * Swagger springdoc-ui 구성 파일
  */

--- a/src/main/java/com/wiztrip/controller/UserController.java
+++ b/src/main/java/com/wiztrip/controller/UserController.java
@@ -4,12 +4,9 @@ import com.wiztrip.dto.UserDto;
 import com.wiztrip.dto.UserRegisterDto;
 import com.wiztrip.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/wiztrip/domain/UserEntity.java
+++ b/src/main/java/com/wiztrip/domain/UserEntity.java
@@ -31,4 +31,5 @@ public class UserEntity extends TimeStamp {
     private Image image; //프로필 사진
 
     private String nickname; //회원 닉네임
+
 }

--- a/src/main/java/com/wiztrip/dto/UserDto.java
+++ b/src/main/java/com/wiztrip/dto/UserDto.java
@@ -2,6 +2,7 @@ package com.wiztrip.dto;
 
 import com.wiztrip.constant.Image;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 
 public class UserDto {

--- a/src/main/java/com/wiztrip/repository/UserRepository.java
+++ b/src/main/java/com/wiztrip/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity,Long> {
     Optional<UserEntity> findByUsername(String username);
 
     boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/wiztrip/service/UserService.java
+++ b/src/main/java/com/wiztrip/service/UserService.java
@@ -59,21 +59,23 @@ public class UserService {
     }
 
 
+    // 닉네임 중복처리
+    public boolean isNicknameExist(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
 
     // 회원가입 처리
     @Transactional
     public UserEntity createUser(UserRegisterDto registrationDto) {
+
         if (!registrationDto.getPassword().equals(registrationDto.getConfirmPassword())) {
-            throw new IllegalArgumentException("Passwords do not match.");
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        // username과 email의 중복 체크
-//        userRepository.findByUsername(registrationDto.getUsername()).ifPresent(u -> {
-//            throw new IllegalArgumentException("Username already in use.");
-//        });
-//        userRepository.findByEmail(registrationDto.getEmail()).ifPresent(u -> {
-//            throw new IllegalArgumentException("Email already in use.");
-//        });
+        // 닉네임 중복 처리
+        if(isNicknameExist(registrationDto.getNickname())) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
 
         UserEntity newUser = new UserEntity();
         newUser.setUsername(registrationDto.getUsername());

--- a/src/main/java/com/wiztrip/service/UserService.java
+++ b/src/main/java/com/wiztrip/service/UserService.java
@@ -6,9 +6,17 @@ import com.wiztrip.dto.UserRegisterDto;
 import com.wiztrip.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -30,15 +38,16 @@ public class UserService {
     @Transactional
     public UserDto.UserResponseDto updateUser(UserDto.UserPatchDto userPatchDto) {
         UserEntity userEntity = userRepository.findById(userPatchDto.getId())
-                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userPatchDto.getId()));
+                .orElseThrow(() -> new EntityNotFoundException("회원 ID 를 찾을 수 없습니다 : " + userPatchDto.getId()));
 
         // UserPatchDto의 정보를 UserEntity에 적용
         userEntity.setUsername(userPatchDto.getUsername());
         userEntity.setEmail(userPatchDto.getEmail());
-        // 필요에 따라 다른 필드도 업데이트
+        userEntity.setNickname(userPatchDto.getNickname());
 
         return convertToUserResponseDto(userRepository.save(userEntity));
     }
+
 
     // 사용자 삭제
     @Transactional


### PR DESCRIPTION
회원가입을 할 경우 nickName 중복 처리 하는 것을 구현했습니다.
브랜치 이름이 profileImage 인 이유는 프로필 이미지와 닉네임 중복 구현을 같이 push 하려했지만
 @moonxxpower 께서 Image 에 대한 수정을 하셔서, 그 부분 merge 후 프로필 이미지 구현 진행이 되어야할 것 같아 
우선 닉네임 중복 구현만 처리했습니다.  