### PR TITLE
Tour API 로 전체여행지 및 세부여행지 불러오기 & 페이징 처리 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ dependencies {
     //REDIS
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.0'
 
+    // api
+    implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+    implementation 'com.google.code.gson:gson'
+
 
 
 

--- a/src/main/java/com/wiztrip/controller/LandmarkController.java
+++ b/src/main/java/com/wiztrip/controller/LandmarkController.java
@@ -3,6 +3,7 @@ package com.wiztrip.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wiztrip.domain.LandmarkEntity;
 import com.wiztrip.dto.LandmarkDto;
+import com.wiztrip.repository.LandmarkRepository;
 import com.wiztrip.service.LandmarkService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,15 @@ import java.util.List;
 public class LandmarkController {
 
     private final LandmarkService landmarkService;
+    private final LandmarkRepository landmarkRepository;
+
+
+    // api 데이터 확인
+    @GetMapping("/api/all")
+    public ResponseEntity<List<LandmarkEntity>> getAlApiLandmarks() {
+        List<LandmarkEntity> landmarks = landmarkRepository.findAll();
+        return ResponseEntity.ok(landmarks);
+    }
 
 
     @Operation(summary = "모든 관광지 조회", description =

--- a/src/main/java/com/wiztrip/controller/LandmarkController.java
+++ b/src/main/java/com/wiztrip/controller/LandmarkController.java
@@ -26,7 +26,12 @@ public class LandmarkController {
     private final LandmarkService landmarkService;
 
 
-    @Operation(summary = "모든 여행지 조회", description = "모든 여행지를 조회합니다.")
+    @Operation(summary = "모든 관광지 조회", description =
+            """
+            관광타입 (12-> 관광지) 로 필터링 한 모든 관광지를 보여줍니다. 
+            한 페이지의 결과수는 100개로 하였습니다.         
+            """
+    )
     @GetMapping
     public ResponseEntity<List<LandmarkDto.LandmarkApiResponseDto>> getAllLandmarks() {
         try {
@@ -39,9 +44,80 @@ public class LandmarkController {
     }
 
 
-    @Operation(summary = "상세 여행지 조회", description = "상세 여행지를 조회합니다.")
+    @Operation(summary = "상세 관광지 조회",
+            description = """
+                   < 대분류(cat1) -> 중분류(cat2) -> 소분류(cat3) >
+                    
+                    * 대분류 A01: 자연관광지
+                        * 중분류 A0101: 자연관광지
+                            * A01010100: 국립공원
+                            * A01010200: 도립공원
+                            * A01010300: 군립공원
+                            * A01010400: 산
+                            * A01010500: 자연생태관광지
+                            * A01010600: 자연휴양림
+                            * A01010700: 수목원
+                            * A01010800: 폭포
+                            * A01010900: 계곡
+                            * A01011000: 약수터
+                            * A01011100: 해안절경
+                            * A01011200: 해수욕장
+                            * A01011300: 섬
+                            * A01011400: 항구/포구
+                            * A01011600: 등대
+                            * A01011700: 호수
+                            * A01011800: 강
+                            * A01011900: 동굴
+                        * 중분류 A0102: 관광자원
+                            * A01020100: 희귀동.식물
+                            * A01020200: 기암괴석
+                    * 대분류 A02: 역사관광지
+                        * 중분류 A0201: 역사관광지
+                            * A02010100: 고궁
+                            * A02010200: 성
+                            * A02010300: 문
+                            * A02010400: 고택
+                            * A02010500: 생가
+                            * A02010600: 민속마을
+                            * A02010700: 유적지/사적지
+                            * A02010800: 사찰
+                            * A02010900: 종교성지
+                            * A02011000: 안보관광
+                        * 중분류 A0202: 휴양관광지
+                            * A02020200: 관광단지
+                            * A02020300: 온천/욕장/스파
+                            * A02020400: 이색찜질방
+                            * A02020500: 헬스투어
+                            * A02020600: 테마공원
+                            * A02020700: 공원
+                            * A02020800: 유람선/잠수함관광
+                        * 중분류 A0203: 체험관광지
+                            * A02030100: 농.산.어촌 체험
+                            * A02030200: 전통체험
+                            * A02030300: 산사체험
+                            * A02030400: 이색체험
+                            * A02030600: 이색거리
+                        * 중분류 A0204: 산업관광지
+                            * A02040400: 발전소
+                            * A02040600: 식음료
+                            * A02040800: 기타
+                            * A02040900: 전자-반도체
+                            * A02041000: 자동차
+                        * 중분류 A0205: 건축/조형물
+                            * A02050100: 다리/대교
+                            * A02050200: 기념탑/기념비/전망대
+                            * A02050300: 분수
+                            * A02050400: 동상
+                            * A02050500: 터널
+                            * A02050600: 유명건물
+                    """
+                    )
     @GetMapping("/landmarks")
-    public ResponseEntity<List<LandmarkDto.LandmarkApiDetailResponseDto>> getLandmarksByContentTypeId(@RequestParam String cat1,@RequestParam String cat2,@RequestParam String cat3) throws URISyntaxException, JsonProcessingException {
+    public ResponseEntity<List<LandmarkDto.LandmarkApiDetailResponseDto>> getLandmarksByContentTypeId(
+            @RequestParam String cat1,
+            @RequestParam String cat2,
+            @RequestParam String cat3)
+            throws URISyntaxException, JsonProcessingException {
         List<LandmarkDto.LandmarkApiDetailResponseDto> landmarks = landmarkService.getLandmarksByContentTypeId(cat1, cat2, cat3);
         return ResponseEntity.ok(landmarks);
     }
@@ -50,32 +126,35 @@ public class LandmarkController {
     // 페이징
     @Operation(summary = "여행지 페이징",
             description = """
+            <파라미터 설명>
+            * pageNo : 페이지 번호 
+            * numOfRows : 보여질 데이터의 개수
+            
+            <ResponseBody>
             content: 페이지 요청에 의해 반환된 랜드마크(또는 기타 엔터티)의 실제 목록. 이 목록의 각 항목은 데이터베이스의 하나의 레코드를 나타냄
-            
+
             pageable: 정렬 순서, 페이지 번호 및 페이지 크기를 포함하여 페이지 매김에 대한 세부 정보를 포함
-            
+
             totalPages: 사용 가능한 총 페이지 수
-            
+
             totalElements: 전체 데이터세트의 총 요소 또는 레코드 수
-            
+
             size, number: 현재 페이지 크기와 페이지 번호를 반영
-            
+
             first, last: 현재 페이지가 첫 번째인지 마지막인지 나타내는 값
-            
+
             sort: 데이터에 적용된 정렬에 대한 정보
-            
+
             empty: 현재 페이지가 비어 있는지 여부를 나타냄
             """)
-    @GetMapping("/page")
-    public ResponseEntity<Page<LandmarkEntity>> getAllLandmarks(
-            // 각 페이지의 크기는 10으로 설정
-            // landmark id로 일단 정렬하는 방식 사용
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "id") String sort) {
+    @GetMapping("/paging")
+    public ResponseEntity<Page<LandmarkDto.LandmarkApiResponseDto>> getLandmarks(
+            @RequestParam(defaultValue = "0") int pageNo,
+            @RequestParam(defaultValue = "10") int numOfRows,
+            @RequestParam(defaultValue = "id") String sort) throws URISyntaxException, JsonProcessingException {
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
-        Page<LandmarkEntity> landmarks = landmarkService.getAllLandmarks(pageable);
+        Pageable pageable = PageRequest.of(pageNo, numOfRows, Sort.by(sort));
+        Page<LandmarkDto.LandmarkApiResponseDto> landmarks = landmarkService.getLandmarksPagingApi(pageable);
         return ResponseEntity.ok(landmarks);
     }
 

--- a/src/main/java/com/wiztrip/controller/LandmarkController.java
+++ b/src/main/java/com/wiztrip/controller/LandmarkController.java
@@ -1,5 +1,6 @@
 package com.wiztrip.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wiztrip.domain.LandmarkEntity;
 import com.wiztrip.dto.LandmarkDto;
 import com.wiztrip.service.LandmarkService;
@@ -9,8 +10,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URISyntaxException;
 import java.util.List;
 
 
@@ -21,22 +25,26 @@ public class LandmarkController {
 
     private final LandmarkService landmarkService;
 
-    // 모든 여행지 조회
-    @Operation(summary = "모든 여행지 조회",description = "모든 여행지를 조회합니다.")
+
+    @Operation(summary = "모든 여행지 조회", description = "모든 여행지를 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<LandmarkDto.LandmarkAllResponseDto>> getAllLandmarks() {
-        List<LandmarkDto.LandmarkAllResponseDto> landmarks = landmarkService.getAllLandmarks();
+    public ResponseEntity<List<LandmarkDto.LandmarkApiResponseDto>> getAllLandmarks() {
+        try {
+            List<LandmarkDto.LandmarkApiResponseDto> landmarks = landmarkService.getLandmarksFromApi(100);
+            return ResponseEntity.ok(landmarks);
+        } catch (Exception e) {
+            // 오류 처리, 예를 들어 API 호출 실패
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+
+    @Operation(summary = "상세 여행지 조회", description = "상세 여행지를 조회합니다.")
+    @GetMapping("/landmarks")
+    public ResponseEntity<List<LandmarkDto.LandmarkApiDetailResponseDto>> getLandmarksByContentTypeId(@RequestParam String cat1,@RequestParam String cat2,@RequestParam String cat3) throws URISyntaxException, JsonProcessingException {
+        List<LandmarkDto.LandmarkApiDetailResponseDto> landmarks = landmarkService.getLandmarksByContentTypeId(cat1, cat2, cat3);
         return ResponseEntity.ok(landmarks);
     }
-
-    // 여행지 상세 조회
-    @Operation(summary = "상세 여행지 조회",description = "landmarkId 를 사용하여 상세 여행지를 조회합니다.")
-    @GetMapping("/{landmarkId}")
-    public ResponseEntity<LandmarkDto.LandmarkDetailResponseDto> getLandmark(@PathVariable Long landmarkId) {
-        LandmarkDto.LandmarkDetailResponseDto landmark = landmarkService.getLandmarkById(landmarkId);
-        return ResponseEntity.ok().body(landmark);
-    }
-
 
 
     // 페이징

--- a/src/main/java/com/wiztrip/controller/LandmarkController.java
+++ b/src/main/java/com/wiztrip/controller/LandmarkController.java
@@ -46,79 +46,24 @@ public class LandmarkController {
 
     @Operation(summary = "상세 관광지 조회",
             description = """
-                   < 대분류(cat1) -> 중분류(cat2) -> 소분류(cat3) >
+                    < 여행지의 contentId 로 상세 여행지의 소개정보를 조회 >
+                    * 여행지의 전화번호
+                    * 쉬는날
+                    * 수용인원
+                    * 영업 시간
+                    * 주차 가능 여부
+                    * 애완동물 출입 가능 여부
+                    * 신용카드 가능 여부
                     
-                    * 대분류 A01: 자연관광지
-                        * 중분류 A0101: 자연관광지
-                            * A01010100: 국립공원
-                            * A01010200: 도립공원
-                            * A01010300: 군립공원
-                            * A01010400: 산
-                            * A01010500: 자연생태관광지
-                            * A01010600: 자연휴양림
-                            * A01010700: 수목원
-                            * A01010800: 폭포
-                            * A01010900: 계곡
-                            * A01011000: 약수터
-                            * A01011100: 해안절경
-                            * A01011200: 해수욕장
-                            * A01011300: 섬
-                            * A01011400: 항구/포구
-                            * A01011600: 등대
-                            * A01011700: 호수
-                            * A01011800: 강
-                            * A01011900: 동굴
-                        * 중분류 A0102: 관광자원
-                            * A01020100: 희귀동.식물
-                            * A01020200: 기암괴석
-                    * 대분류 A02: 역사관광지
-                        * 중분류 A0201: 역사관광지
-                            * A02010100: 고궁
-                            * A02010200: 성
-                            * A02010300: 문
-                            * A02010400: 고택
-                            * A02010500: 생가
-                            * A02010600: 민속마을
-                            * A02010700: 유적지/사적지
-                            * A02010800: 사찰
-                            * A02010900: 종교성지
-                            * A02011000: 안보관광
-                        * 중분류 A0202: 휴양관광지
-                            * A02020200: 관광단지
-                            * A02020300: 온천/욕장/스파
-                            * A02020400: 이색찜질방
-                            * A02020500: 헬스투어
-                            * A02020600: 테마공원
-                            * A02020700: 공원
-                            * A02020800: 유람선/잠수함관광
-                        * 중분류 A0203: 체험관광지
-                            * A02030100: 농.산.어촌 체험
-                            * A02030200: 전통체험
-                            * A02030300: 산사체험
-                            * A02030400: 이색체험
-                            * A02030600: 이색거리
-                        * 중분류 A0204: 산업관광지
-                            * A02040400: 발전소
-                            * A02040600: 식음료
-                            * A02040800: 기타
-                            * A02040900: 전자-반도체
-                            * A02041000: 자동차
-                        * 중분류 A0205: 건축/조형물
-                            * A02050100: 다리/대교
-                            * A02050200: 기념탑/기념비/전망대
-                            * A02050300: 분수
-                            * A02050400: 동상
-                            * A02050500: 터널
-                            * A02050600: 유명건물
+                    를 조회
+                   
                     """
                     )
     @GetMapping("/landmarks")
     public ResponseEntity<List<LandmarkDto.LandmarkApiDetailResponseDto>> getLandmarksByContentTypeId(
-            @RequestParam String cat1,
-            @RequestParam String cat2,
-            @RequestParam String cat3)
+            @RequestParam String contentId)
             throws URISyntaxException, JsonProcessingException {
-        List<LandmarkDto.LandmarkApiDetailResponseDto> landmarks = landmarkService.getLandmarksByContentTypeId(cat1, cat2, cat3);
+        List<LandmarkDto.LandmarkApiDetailResponseDto> landmarks = landmarkService.getLandmarksByContentTypeId(contentId);
         return ResponseEntity.ok(landmarks);
     }
 

--- a/src/main/java/com/wiztrip/controller/UserController.java
+++ b/src/main/java/com/wiztrip/controller/UserController.java
@@ -42,11 +42,12 @@ public class UserController {
     // 회원가입 처리
     @Operation(summary = "회원가입 처리",
             description = """ 
-            username
-            email
-            password
-            confirmpassword
-            nickname 입력
+            <회원가입>
+            * username
+            * email
+            * password
+            * confirmpassword
+            * nickname 입력
             """)
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@RequestBody UserRegisterDto registrationDto) {

--- a/src/main/java/com/wiztrip/domain/LandmarkEntity.java
+++ b/src/main/java/com/wiztrip/domain/LandmarkEntity.java
@@ -19,6 +19,10 @@ public class LandmarkEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    private Long contentId;
+
+    private Long contentTypeId;
+
     @NotNull
     private String name;
 

--- a/src/main/java/com/wiztrip/dto/LandmarkDto.java
+++ b/src/main/java/com/wiztrip/dto/LandmarkDto.java
@@ -86,22 +86,32 @@ public class LandmarkDto {
     @Builder
     public static class LandmarkApiDetailResponseDto {
 
-
-        private String address;
-
-        private String imagePath;
-
         private Long contentId;
 
-        private Long contentTypeId;
+      //  private String address;
 
-        private String title;
+     //   private String imagePath;
 
-        private String cat1;
+//        private Long contentTypeId;
+//
+//        private String title;
 
-        private String cat2;
+        private String infocenter;  // Tel number
 
-        private String cat3;
+        private String restDate;    // 쉬는 날
+
+        private String accomcount;  // 수용 인원
+
+        private String useTime;    // 영업 시간
+
+        private String parking;     // 주차 가능 여부
+
+        private String checkPet;    // 애완동물 출입 가능 여부
+
+        private String checkCreditCard; // 신용카드 가능 여부
+
+
+
 
     }
 

--- a/src/main/java/com/wiztrip/dto/LandmarkDto.java
+++ b/src/main/java/com/wiztrip/dto/LandmarkDto.java
@@ -67,12 +67,11 @@ public class LandmarkDto {
     @Builder
     public static class LandmarkApiResponseDto {
 
+        private Long contentId;
 
         private String address;
 
         private String imagePath;
-
-        private Long contentId;
 
         private Long contentTypeId;
 
@@ -87,14 +86,6 @@ public class LandmarkDto {
     public static class LandmarkApiDetailResponseDto {
 
         private Long contentId;
-
-      //  private String address;
-
-     //   private String imagePath;
-
-//        private Long contentTypeId;
-//
-//        private String title;
 
         private String infocenter;  // Tel number
 

--- a/src/main/java/com/wiztrip/dto/LandmarkDto.java
+++ b/src/main/java/com/wiztrip/dto/LandmarkDto.java
@@ -59,4 +59,51 @@ public class LandmarkDto {
         private List<LandmarkImageDto> imageList;
 
     }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class LandmarkApiResponseDto {
+
+
+        private String address;
+
+        private String imagePath;
+
+        private Long contentId;
+
+        private Long contentTypeId;
+
+        private String title;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class LandmarkApiDetailResponseDto {
+
+
+        private String address;
+
+        private String imagePath;
+
+        private Long contentId;
+
+        private Long contentTypeId;
+
+        private String title;
+
+        private String cat1;
+
+        private String cat2;
+
+        private String cat3;
+
+    }
+
+
 }

--- a/src/main/java/com/wiztrip/service/LandmarkService.java
+++ b/src/main/java/com/wiztrip/service/LandmarkService.java
@@ -9,6 +9,7 @@ import com.wiztrip.tourapi.ApiController;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +44,7 @@ public class LandmarkService {
         // API 응답 필드를 LandmarkDto 필드에 매핑
         return LandmarkDto.LandmarkApiResponseDto.builder()
                 .contentId(Long.parseLong(apiData.getOrDefault("contentid", "0").toString())) // 'contentid'를 imageId로 매핑
-                .imageName((String) apiData.get("addr1")) // 'addr1'을 imageName으로 매핑
+                .address((String) apiData.get("addr1")) // 'addr1'을 imageName으로 매핑
                 .imagePath((String) apiData.get("firstimage")) // 'firstimage'를 imagePath로 매핑
                 .contentTypeId(Long.parseLong(apiData.getOrDefault("contenttypeid", "0").toString())) // 'contenttypeid'를 contentTypeId로 매핑
                 .title((String) apiData.get("title")) // 'title'을 title로 매핑
@@ -75,8 +76,22 @@ public class LandmarkService {
     }
 
     // 여행지 페이징 처리
-    public Page<LandmarkEntity> getAllLandmarks(Pageable pageable) {
-        return landmarkRepository.findAll(pageable);
+    public Page<LandmarkDto.LandmarkApiResponseDto> getLandmarksPagingApi(Pageable pageable)
+            throws URISyntaxException, JsonProcessingException {
+
+        // ApiController를 사용하여 페이징 처리된 데이터 가져오기
+        List<Map<String, Object>> apiData = apiController.pagingData(pageable.getPageNumber(), pageable.getPageSize());
+
+        // Stream을 사용하여 DTO 변환
+        List<LandmarkDto.LandmarkApiResponseDto> content = apiData.stream()
+                .map(this::convertToAllLandmarkDto)
+                .collect(Collectors.toList());
+
+        long totalElements = 100; // 총 요소 수 계산
+        int totalPages = (int) Math.ceil((double) totalElements / (double) pageable.getPageSize());
+
+        // PageImpl 객체를 사용하여 Page 반환
+        return new PageImpl<>(content, pageable, totalElements);
     }
 
 

--- a/src/main/java/com/wiztrip/service/LandmarkService.java
+++ b/src/main/java/com/wiztrip/service/LandmarkService.java
@@ -52,10 +52,10 @@ public class LandmarkService {
     }
 
     // 세부 여행지 불러오기
-    public List<LandmarkDto.LandmarkApiDetailResponseDto> getLandmarksByContentTypeId(String cat1,String cat2,String cat3)
+    public List<LandmarkDto.LandmarkApiDetailResponseDto> getLandmarksByContentTypeId(String contentId)
             throws URISyntaxException, JsonProcessingException {
 
-        List<Map<String, Object>> detailapiData = apiController.getLandmarkData(cat1, cat2, cat3); // 필요한 파라미터 제공
+        List<Map<String, Object>> detailapiData = apiController.getLandmarkData(contentId); // 필요한 파라미터 제공
         return detailapiData.stream()
                 .map(this::convertToDetailLandmarkDto)
                 .collect(Collectors.toList());
@@ -64,14 +64,14 @@ public class LandmarkService {
     private LandmarkDto.LandmarkApiDetailResponseDto convertToDetailLandmarkDto(Map<String, Object> detailapiData) {
         // API 응답 필드를 LandmarkDto 필드에 매핑
         return LandmarkDto.LandmarkApiDetailResponseDto.builder()
-                .contentId(Long.parseLong(detailapiData.getOrDefault("contentid", "0").toString())) // 'contentid'를 imageId로 매핑
-                .address((String) detailapiData.get("addr1")) // 'addr1'을 imageName으로 매핑
-                .imagePath((String) detailapiData.get("firstimage")) // 'firstimage'를 imagePath로 매핑
-                .contentTypeId(Long.parseLong(detailapiData.getOrDefault("contenttypeid", "0").toString())) // 'contenttypeid'를 contentTypeId로 매핑
-                .cat1((String) detailapiData.get("cat1"))
-                .cat2((String) detailapiData.get("cat2"))
-                .cat3((String) detailapiData.get("cat3"))
-                .title((String) detailapiData.get("title")) // 'title'을 title로 매핑
+                .contentId(Long.parseLong(detailapiData.getOrDefault("contentid", "0").toString())) // 'contentid'를 contentId ㅇ 매핑
+                .infocenter((String) detailapiData.get("infocenter"))
+                .restDate((String) detailapiData.get("restdate"))
+                .accomcount((String) detailapiData.get("accomcount"))
+                .useTime((String) detailapiData.get("usetime"))
+                .parking((String) detailapiData.get("parking"))
+                .checkPet((String) detailapiData.get("chkpet"))
+                .checkCreditCard((String) detailapiData.get("chkcreditcard"))
                 .build();
     }
 

--- a/src/main/java/com/wiztrip/service/LandmarkService.java
+++ b/src/main/java/com/wiztrip/service/LandmarkService.java
@@ -1,9 +1,11 @@
 package com.wiztrip.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.wiztrip.domain.LandmarkEntity;
 import com.wiztrip.dto.LandmarkDto;
 import com.wiztrip.mapstruct.LandmarkMapper;
 import com.wiztrip.repository.LandmarkRepository;
+import com.wiztrip.tourapi.ApiController;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -11,7 +13,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,23 +25,54 @@ import java.util.stream.Collectors;
 public class LandmarkService {
 
     private final LandmarkRepository landmarkRepository;
-    private final LandmarkMapper landmarkMapper;
+    private final ApiController apiController;
 
 
-    // 모든 여행지 조회
-    public List<LandmarkDto.LandmarkAllResponseDto> getAllLandmarks() {
-        return landmarkRepository.findAll().stream()
-                .map(landmarkMapper::entityToAllResponseDto) // 'entityToLandmarkAllResponseDto' 메서드 사용
+    // API 데이터 가져오기 및 처리
+    public List<LandmarkDto.LandmarkApiResponseDto> getLandmarksFromApi(int numOfRows)
+            throws URISyntaxException, JsonProcessingException {
+
+        List<Map<String, Object>> apiData = apiController.getData(numOfRows); // 필요한 파라미터 제공
+        return apiData.stream()
+                .map(this::convertToAllLandmarkDto)
                 .collect(Collectors.toList());
     }
 
-    // 여행지 상세 조회
-    public LandmarkDto.LandmarkDetailResponseDto getLandmarkById(Long landmarkId) {
-        LandmarkEntity landmark = landmarkRepository.findById(landmarkId)
-                .orElseThrow(() -> new EntityNotFoundException("Landmark 의 id를 찾을 수 없습니다 : " + landmarkId));
-        return landmarkMapper.entityToDetailResponseDto(landmark); // 'entityToLandmarkDetailResponseDto' 메서드 사용
+    // 전체 여행지 불러오기
+    private LandmarkDto.LandmarkApiResponseDto convertToAllLandmarkDto(Map<String, Object> apiData) {
+        // API 응답 필드를 LandmarkDto 필드에 매핑
+        return LandmarkDto.LandmarkApiResponseDto.builder()
+                .contentId(Long.parseLong(apiData.getOrDefault("contentid", "0").toString())) // 'contentid'를 imageId로 매핑
+                .imageName((String) apiData.get("addr1")) // 'addr1'을 imageName으로 매핑
+                .imagePath((String) apiData.get("firstimage")) // 'firstimage'를 imagePath로 매핑
+                .contentTypeId(Long.parseLong(apiData.getOrDefault("contenttypeid", "0").toString())) // 'contenttypeid'를 contentTypeId로 매핑
+                .title((String) apiData.get("title")) // 'title'을 title로 매핑
+                .build();
     }
 
+    // 세부 여행지 불러오기
+    public List<LandmarkDto.LandmarkApiDetailResponseDto> getLandmarksByContentTypeId(String cat1,String cat2,String cat3)
+            throws URISyntaxException, JsonProcessingException {
+
+        List<Map<String, Object>> detailapiData = apiController.getLandmarkData(cat1, cat2, cat3); // 필요한 파라미터 제공
+        return detailapiData.stream()
+                .map(this::convertToDetailLandmarkDto)
+                .collect(Collectors.toList());
+    }
+
+    private LandmarkDto.LandmarkApiDetailResponseDto convertToDetailLandmarkDto(Map<String, Object> detailapiData) {
+        // API 응답 필드를 LandmarkDto 필드에 매핑
+        return LandmarkDto.LandmarkApiDetailResponseDto.builder()
+                .contentId(Long.parseLong(detailapiData.getOrDefault("contentid", "0").toString())) // 'contentid'를 imageId로 매핑
+                .address((String) detailapiData.get("addr1")) // 'addr1'을 imageName으로 매핑
+                .imagePath((String) detailapiData.get("firstimage")) // 'firstimage'를 imagePath로 매핑
+                .contentTypeId(Long.parseLong(detailapiData.getOrDefault("contenttypeid", "0").toString())) // 'contenttypeid'를 contentTypeId로 매핑
+                .cat1((String) detailapiData.get("cat1"))
+                .cat2((String) detailapiData.get("cat2"))
+                .cat3((String) detailapiData.get("cat3"))
+                .title((String) detailapiData.get("title")) // 'title'을 title로 매핑
+                .build();
+    }
 
     // 여행지 페이징 처리
     public Page<LandmarkEntity> getAllLandmarks(Pageable pageable) {

--- a/src/main/java/com/wiztrip/tourapi/ApiController.java
+++ b/src/main/java/com/wiztrip/tourapi/ApiController.java
@@ -74,7 +74,7 @@ public class ApiController {
 
         return testItemMap;
     }
-
+// }
 
     // 세부 여행지 메서드
     public List<Map<String, Object>> getLandmarkData(String contentId)

--- a/src/main/java/com/wiztrip/tourapi/ApiController.java
+++ b/src/main/java/com/wiztrip/tourapi/ApiController.java
@@ -86,8 +86,8 @@ public class ApiController {
         String MobileApp = "Test";      // APP name
         String _type = "json";          // 받을 데이터 타입
         String contentTypeId = "12";    // 관광지(12)
-        String numOfRows = "1";
-        String pageNo = "1";
+        int numOfRows = 1;
+        int pageNo = 1;
 
         // 서비스 키
         String serviceKey = "FI6qPw0hnomFTdMepcDdUiUO1wVBjkwNyUrPJxdCTP1SVxDMnBOb0LWcjrGyAi8Mz4zzC%2B9yH1RH8Twh1rIrdA%3D%3D";
@@ -136,6 +136,65 @@ public class ApiController {
 
 
         return testItemMap;
+    }
+
+
+    // 페이징
+    public List<Map<String, Object>> pagingData(int pageNo,int numOfRows)
+            throws URISyntaxException, JsonProcessingException {
+
+        // Base URL + API 호출 주소
+        String link = "https://apis.data.go.kr/B551011/KorService1/areaBasedList1";
+        String MobileOS = "ETC";        // 실행환경
+        String MobileApp = "Test";      // APP name
+        String _type = "json";          // 받을 데이터 타입
+        String contentTypeId = "12";    // 관광지(12)
+
+        // 서비스 키
+        String serviceKey = "FI6qPw0hnomFTdMepcDdUiUO1wVBjkwNyUrPJxdCTP1SVxDMnBOb0LWcjrGyAi8Mz4zzC%2B9yH1RH8Twh1rIrdA%3D%3D";
+
+        String url = link + "?" +
+                "&MobileOS=" + MobileOS +
+                "&MobileApp=" + MobileApp +
+                "&_type=" + _type +
+                "&numOfRows=" + numOfRows +
+                "&pageNo=" + pageNo +
+                "&contentTypeId=" + contentTypeId +
+                "&serviceKey=" + serviceKey;
+
+        URI uri = new URI(url);         // 작선한 문자열로 URL 생성
+        RestTemplate restTemplate = new RestTemplate();     // HTTP 요청 수행
+        HttpHeaders headers2 = new HttpHeaders();            // HTTP 요청 헤더 생성
+
+        // content-type 으로 데이터 타입 지정 , 여기서는 UTF-8
+        headers2.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // get 요청
+        String response = restTemplate.getForObject(
+                uri,            // 요청 보낼 url
+                String.class    // 응답을 문자열로 받겠음.
+        );
+        // 로그 출력
+        log.info("Paging API Response: {}", response);
+
+        // 데이터 추출
+        Map<String, Object> map = new ObjectMapper().readValue(response.toString(), Map.class);
+        Map<String, Object> responseMap = (Map<String, Object>) map.get("response");
+        Map<String, Object> bodyMap = (Map<String, Object>) responseMap.get("body");
+        Map<String, Object> itemsMap = (Map<String, Object>) bodyMap.get("items");
+        List<Map<String, Object>> itemMap = (List<Map<String, Object>>) itemsMap.get("item");
+
+        //state에 있는 정보만 들고오기
+        List<Map<String, Object>> testItemMap = itemMap.stream()
+//                .filter(item -> {
+//                    Object value = item.get("addr1");
+//                    return value != null && value.toString().contains(state);
+//                })
+                .collect(Collectors.toList());
+
+
+        return testItemMap;
+
     }
 
 

--- a/src/main/java/com/wiztrip/tourapi/ApiController.java
+++ b/src/main/java/com/wiztrip/tourapi/ApiController.java
@@ -1,0 +1,142 @@
+package com.wiztrip.tourapi;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Component
+@Slf4j
+public class ApiController {
+
+    public List<Map<String, Object>> getData(int numOfRows)
+            throws URISyntaxException, JsonProcessingException {
+
+        // Base URL + API 호출 주소
+        String link = "https://apis.data.go.kr/B551011/KorService1/areaBasedList1";
+        String MobileOS = "ETC";        // 실행환경
+        String MobileApp = "Test";      // APP name
+        String _type = "json";          // 받을 데이터 타입
+        String contentTypeId = "12";    // 관광지(12)
+
+        // 서비스 키
+        String serviceKey = "FI6qPw0hnomFTdMepcDdUiUO1wVBjkwNyUrPJxdCTP1SVxDMnBOb0LWcjrGyAi8Mz4zzC%2B9yH1RH8Twh1rIrdA%3D%3D";
+
+        String url = link + "?" +
+                "&MobileOS=" + MobileOS +
+                "&MobileApp=" + MobileApp +
+                "&_type=" + _type +
+//                "&areaCode=" + areaCode +               // 받아온 지역 코드
+                "&contentTypeId=" + contentTypeId +     // 받아온 관광 타입
+                "&numOfRows=" + numOfRows +             // 출력할 데이터 개수
+                "&serviceKey=" + serviceKey;
+
+        URI uri = new URI(url);         // 작선한 문자열로 URL 생성
+        RestTemplate restTemplate = new RestTemplate();     // HTTP 요청 수행
+        HttpHeaders headers = new HttpHeaders();            // HTTP 요청 헤더 생성
+
+        // content-type 으로 데이터 타입 지정 , 여기서는 UTF-8
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // get 요청
+        String response = restTemplate.getForObject(
+                uri,            // 요청 보낼 url
+                String.class    // 응답을 문자열로 받겠음.
+        );
+        // 로그 출력
+        log.info("API Response: {}", response);
+
+        // 데이터 추출
+        Map<String, Object> map = new ObjectMapper().readValue(response.toString(), Map.class);
+        Map<String, Object> responseMap = (Map<String, Object>) map.get("response");
+        Map<String, Object> bodyMap = (Map<String, Object>) responseMap.get("body");
+        Map<String, Object> itemsMap = (Map<String, Object>) bodyMap.get("items");
+        List<Map<String, Object>> itemMap = (List<Map<String, Object>>) itemsMap.get("item");
+
+        //state에 있는 정보만 들고오기
+        List<Map<String, Object>> testItemMap = itemMap.stream()
+//                .filter(item -> {
+//                    Object value = item.get("addr1");
+//                    return value != null && value.toString().contains(state);
+//                })
+                .collect(Collectors.toList());
+
+
+        return testItemMap;
+    }
+
+
+    // 세부 여행지 메서드
+    public List<Map<String, Object>> getLandmarkData(String cat1,String cat2,String cat3)
+            throws URISyntaxException, JsonProcessingException {
+
+        // Base URL + API 호출 주소
+        String link = "https://apis.data.go.kr/B551011/KorService1/areaBasedList1";
+        String MobileOS = "ETC";        // 실행환경
+        String MobileApp = "Test";      // APP name
+        String _type = "json";          // 받을 데이터 타입
+        String contentTypeId = "12";    // 관광지(12)
+        String numOfRows = "1";
+        String pageNo = "1";
+
+        // 서비스 키
+        String serviceKey = "FI6qPw0hnomFTdMepcDdUiUO1wVBjkwNyUrPJxdCTP1SVxDMnBOb0LWcjrGyAi8Mz4zzC%2B9yH1RH8Twh1rIrdA%3D%3D";
+
+        String url = link + "?" +
+                "&MobileOS=" + MobileOS +
+                "&MobileApp=" + MobileApp +
+                "&_type=" + _type +
+                "&numOfRows=" + numOfRows +
+                "&pageNo=" + pageNo +
+                "&contentTypeId=" + contentTypeId +
+                "&cat1=" + cat1 +
+                "&cat2=" + cat2 +
+                "&cat3=" + cat3 +
+                "&serviceKey=" + serviceKey;
+
+        URI uri = new URI(url);         // 작선한 문자열로 URL 생성
+        RestTemplate restTemplate = new RestTemplate();     // HTTP 요청 수행
+        HttpHeaders headers2 = new HttpHeaders();            // HTTP 요청 헤더 생성
+
+        // content-type 으로 데이터 타입 지정 , 여기서는 UTF-8
+        headers2.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // get 요청
+        String response = restTemplate.getForObject(
+                uri,            // 요청 보낼 url
+                String.class    // 응답을 문자열로 받겠음.
+        );
+        // 로그 출력
+        log.info("Detail API Response: {}", response);
+
+        // 데이터 추출
+        Map<String, Object> map = new ObjectMapper().readValue(response.toString(), Map.class);
+        Map<String, Object> responseMap = (Map<String, Object>) map.get("response");
+        Map<String, Object> bodyMap = (Map<String, Object>) responseMap.get("body");
+        Map<String, Object> itemsMap = (Map<String, Object>) bodyMap.get("items");
+        List<Map<String, Object>> itemMap = (List<Map<String, Object>>) itemsMap.get("item");
+
+        //state에 있는 정보만 들고오기
+        List<Map<String, Object>> testItemMap = itemMap.stream()
+//                .filter(item -> {
+//                    Object value = item.get("addr1");
+//                    return value != null && value.toString().contains(state);
+//                })
+                .collect(Collectors.toList());
+
+
+        return testItemMap;
+    }
+
+
+}

--- a/src/main/java/com/wiztrip/tourapi/ApiController.java
+++ b/src/main/java/com/wiztrip/tourapi/ApiController.java
@@ -77,11 +77,11 @@ public class ApiController {
 
 
     // 세부 여행지 메서드
-    public List<Map<String, Object>> getLandmarkData(String cat1,String cat2,String cat3)
+    public List<Map<String, Object>> getLandmarkData(String contentId)
             throws URISyntaxException, JsonProcessingException {
 
         // Base URL + API 호출 주소
-        String link = "https://apis.data.go.kr/B551011/KorService1/areaBasedList1";
+        String link = "https://apis.data.go.kr/B551011/KorService1/detailIntro1";
         String MobileOS = "ETC";        // 실행환경
         String MobileApp = "Test";      // APP name
         String _type = "json";          // 받을 데이터 타입
@@ -99,9 +99,7 @@ public class ApiController {
                 "&numOfRows=" + numOfRows +
                 "&pageNo=" + pageNo +
                 "&contentTypeId=" + contentTypeId +
-                "&cat1=" + cat1 +
-                "&cat2=" + cat2 +
-                "&cat3=" + cat3 +
+                "&contentId=" + contentId +
                 "&serviceKey=" + serviceKey;
 
         URI uri = new URI(url);         // 작선한 문자열로 URL 생성


### PR DESCRIPTION
tour api 를 통해 전체여행지를 (관광지 타입=12(관광지)) 로 하여 불러왔고,
대부분의 공개 API는 고유 식별자(ID)를 기반으로 한 개별 항목의 직접적인 검색을 지원하지 않는 경우가 많아, api 에서 제공하는 다른 파라미터들로 여행지를 찾는 방법을 선택하여 구현하였습니다. 

이를 바탕으로 Landmark 페이징도 구현완료 하였습니다.

확인해주시고 수정할 것 있으면 말씀 부탁드립니다!!