### PR TITLE
[기능 향상 및 구현] 공유 url 생성 및 Trip 수정

### DIFF
--- a/src/main/java/com/wiztrip/Init.java
+++ b/src/main/java/com/wiztrip/Init.java
@@ -64,6 +64,10 @@ public class Init {
             LocalDate localDate = LocalDate.of(2023, 12, 1+i);
             trip.setStartDate(localDate);
             trip.setFinishDate(localDate);
+
+            UserEntity owner = userRepository.findByUsername("testusername" + i).orElse(null);
+            trip.setOwner(owner);
+
             tripRepository.save(trip);
         }
 

--- a/src/main/java/com/wiztrip/Init.java
+++ b/src/main/java/com/wiztrip/Init.java
@@ -85,8 +85,6 @@ public class Init {
                 plan.setUser(userEntityList.get(i));
                 plan.setTrip(tripEntityList.get(k));
 
-                plan.setName("testplanname" + k);
-
                 Address address = new Address("testplanroadnameaddress" + i, "testplanlocaladdress" + i);
                 plan.setAddress(address);
 

--- a/src/main/java/com/wiztrip/controller/TripController.java
+++ b/src/main/java/com/wiztrip/controller/TripController.java
@@ -81,7 +81,22 @@ public class TripController {
         return ResponseEntity.ok().body(tripService.deleteTrip(principalDetails.getUser(),tripId));
     }
 
+    // 공유 url 생성
+    @Operation(summary = "Trip 공유 url 생성",
+            description = "TripId를 통해 10글자의 랜덤한 url을 생성합니다. 유효 기간이 지났을 경우, 새로운 url을 생성하고, 만약 유효 기간이 지나지 않았다면, 이전에 생성한 url을 반환합니다.")
+    @PostMapping("/{tripId}")
+    public ResponseEntity<TripDto.TripUrlResponseDto> createTripUrl (
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable("tripId") Long tripId) {
+        return ResponseEntity.ok().body(tripService.createTripUrl(principalDetails.getUser(), tripId));
+    }
 
-
-
+    // 공유 url 조회
+    @Operation(summary = "Trip 공유 url 조회",
+            description = "user를 고려하지 않고, url을 통해 해당하는 tripId를 조회합니다.")
+    @GetMapping("/{url}")
+    public ResponseEntity<TripDto.TripIdResponseDto> getTripUrl (
+            @PathVariable("url") String url) {
+        return ResponseEntity.ok().body(tripService.getTripUrl(url));
+    }
 }

--- a/src/main/java/com/wiztrip/controller/TripController.java
+++ b/src/main/java/com/wiztrip/controller/TripController.java
@@ -80,7 +80,7 @@ public class TripController {
         return ResponseEntity.ok().body(tripService.updateTrip(principalDetails.getUser(),tripPatchDto));
     }
 
-    @Operation(summary = "Trip 삭제", description = "trip id를 통해 trip 삭제")
+    @Operation(summary = "Trip 삭제", description = "trip id를 통해 trip 삭제합니다. Owner(Trip을 생성한 사람)만 삭제할 수 있습니다.")
     @DeleteMapping
     public ResponseEntity<String> deleteTrip(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
@@ -106,5 +106,15 @@ public class TripController {
     public ResponseEntity<TripDto.TripIdResponseDto> getTripUrl (
             @PathVariable("url") String url) {
         return ResponseEntity.ok().body(tripService.getTripUrl(url));
+    }
+
+    // 전체 여행 계획 종료
+    @Operation(summary = "Trip 종료",
+            description = "TripId를 통해 해당 Trip의 상태를 false(기본값)에서 true로 변경합니다. Owner(Trip을 생성한 사람)만 종료할 수 있으며, 종료할 경우, 더 이상 Trip을 수정할 수 없습니다.")
+    @PatchMapping("/{tripId}")
+    public ResponseEntity<String> updateTripFinish (
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable("tripId") Long tripId) {
+        return ResponseEntity.ok().body(tripService.updateTripFinish(principalDetails.getUser(), tripId));
     }
 }

--- a/src/main/java/com/wiztrip/controller/TripController.java
+++ b/src/main/java/com/wiztrip/controller/TripController.java
@@ -1,6 +1,7 @@
 package com.wiztrip.controller;
 
 import com.wiztrip.config.spring_security.auth.PrincipalDetails;
+import com.wiztrip.dto.ListDto;
 import com.wiztrip.dto.TripDto;
 import com.wiztrip.service.TripService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -64,6 +65,13 @@ public class TripController {
     ) {
         PageRequest pageRequest = PageRequest.of(pageNum, pageSize, sortDirection, sortBy);
         return ResponseEntity.ok().body(tripService.getTripDetailsPageByUser(principalDetails.getUser(), pageRequest));
+    }
+
+    @Operation(summary = "User가 속한 Trip detail 조회",description = "User가 속한 Trip의 Detail을 담은 Page 조회. JWT Token 필수!!!")
+    @GetMapping("/with-details")
+    public ResponseEntity<ListDto<TripDto.TripResponseDto>> getTripDetailsByUser(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok().body(tripService.getTripDetailsByUser(principalDetails.getUser()));
     }
 
     @Operation(summary = "Trip 수정", description = "TripPatchDto를 통해 Trip 수정. TripPatchDto.userIdList, TripPatchDto.planIdList를 조정해 참여중인 User, 포함된 Plan을 추가, 삭제 할 수 있음. 수정하고싶은 attribute만 포함해서 보내야함!! ")

--- a/src/main/java/com/wiztrip/domain/PlanEntity.java
+++ b/src/main/java/com/wiztrip/domain/PlanEntity.java
@@ -18,8 +18,6 @@ public class PlanEntity { //Trip의 세부 사항. 장소, 시간, 예산 등
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    private String name; //계획 이름. ~~식당, ~~호텔 등
-
     @Embedded
     private Address address;
 

--- a/src/main/java/com/wiztrip/domain/TripEntity.java
+++ b/src/main/java/com/wiztrip/domain/TripEntity.java
@@ -28,8 +28,15 @@ public class TripEntity {
     private List<TripUserEntity> tripUserEntityList = new ArrayList<>();
 
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TripUrlEntity> tripUrlEntityList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlanEntity> planEntityList = new ArrayList<>();
 
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemoEntity> memoEntityList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewEntity> reviewEntityList = new ArrayList<>();
+
 }

--- a/src/main/java/com/wiztrip/domain/TripEntity.java
+++ b/src/main/java/com/wiztrip/domain/TripEntity.java
@@ -24,6 +24,10 @@ public class TripEntity {
 
     private String destination; //목적지. 사용자가 정할 수 있으면 좋을듯?? 00과 부산여행, 00과 엠티 등등
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private UserEntity owner;
+
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TripUserEntity> tripUserEntityList = new ArrayList<>();
 

--- a/src/main/java/com/wiztrip/domain/TripEntity.java
+++ b/src/main/java/com/wiztrip/domain/TripEntity.java
@@ -43,4 +43,6 @@ public class TripEntity {
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewEntity> reviewEntityList = new ArrayList<>();
 
+    private boolean finished;
+
 }

--- a/src/main/java/com/wiztrip/domain/TripUrlEntity.java
+++ b/src/main/java/com/wiztrip/domain/TripUrlEntity.java
@@ -1,0 +1,23 @@
+package com.wiztrip.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class TripUrlEntity {
+
+    @Id
+    @Column(name = "trip_url_id")
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private TripEntity trip;
+
+    private String url;
+
+}

--- a/src/main/java/com/wiztrip/dto/PlanDto.java
+++ b/src/main/java/com/wiztrip/dto/PlanDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.wiztrip.constant.Address;
 import com.wiztrip.constant.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -18,11 +17,6 @@ public class PlanDto {
     @NoArgsConstructor
     @Builder
     public static class PlanPostDto {
-
-        @Schema(description = "계획 이름", example = "제육집")
-        @NotBlank(message = "name을 입력해주세요")
-        private String name; //계획 이름. ~~식당, ~~호텔 등
-
         @Schema(description = "Plan의 주소")
         private Address address;
 
@@ -50,11 +44,9 @@ public class PlanDto {
     @NoArgsConstructor
     @Builder
     public static class PlanResponseDto {
+
         @Schema(description = "plan id", example = "1")
         private Long planId;
-
-        @Schema(description = "계획 이름", example = "제육집")
-        private String name; //계획 이름. ~~식당, ~~호텔 등
 
         @Schema(description = "Plan의 주소")
         private Address address;
@@ -80,6 +72,7 @@ public class PlanDto {
 
         @Schema(description = "Plan이 속한 Trip의 id", example = "1")
         private Long tripId; //plan이 속한 trip의 id
+
     }
 
     @Getter
@@ -88,12 +81,10 @@ public class PlanDto {
     @NoArgsConstructor
     @Builder
     public static class PlanPatchDto {
+
         @Schema(description = "plan id", example = "1")
         @NotNull(message = "planId를 입력해주세요.")
         private Long planId;
-
-        @Schema(description = "계획 이름", example = "제육집")
-        private String name; //계획 이름. ~~식당, ~~호텔 등
 
         @Schema(description = "Plan의 주소")
         private Address address;
@@ -113,7 +104,6 @@ public class PlanDto {
 
         @Schema(description = "Plan의 종류", example = "RESTAURANT")
         private Category category;
+
     }
-
-
 }

--- a/src/main/java/com/wiztrip/dto/TripDto.java
+++ b/src/main/java/com/wiztrip/dto/TripDto.java
@@ -106,4 +106,25 @@ public class TripDto {
         private List<Long> planIdList = new ArrayList<>(); //만약 여러개의 plan을 한번에 삭제하려고 할 때 필요
     }
 
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class TripUrlResponseDto {
+
+        private String url;
+
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class TripIdResponseDto {
+
+        private Long tripId;
+
+    }
 }

--- a/src/main/java/com/wiztrip/dto/TripDto.java
+++ b/src/main/java/com/wiztrip/dto/TripDto.java
@@ -76,6 +76,9 @@ public class TripDto {
                 "  ]")
         private List<Long> planIdList = new ArrayList<>(); //만약 여러개의 plan을 한번에 삭제하려고 할 때 필요
 
+        @Schema(description = "종료 여부", example = "false")
+        private boolean finished;
+
     }
 
     @Getter

--- a/src/main/java/com/wiztrip/dto/TripDto.java
+++ b/src/main/java/com/wiztrip/dto/TripDto.java
@@ -37,6 +37,7 @@ public class TripDto {
                 "    1\n" +
                 "  ]")
         private List<Long> userIdList = new ArrayList<>();
+
     }
 
     @Getter
@@ -45,6 +46,7 @@ public class TripDto {
     @NoArgsConstructor
     @Builder
     public static class TripResponseDto {
+
         @Schema(description = "trip id", example = "1")
         private Long tripId;
 
@@ -61,6 +63,9 @@ public class TripDto {
         @Schema(description = "목적지 이름", example = "제주도")
         private String destination; //목적지
 
+        @Schema(description = "owner(Trip을 생성한 사람) id", example = "1")
+        private Long ownerId;
+
         @Schema(description = "참여하는 User의 id", example = "[\n" +
                 "    1\n" +
                 "  ]")
@@ -70,6 +75,7 @@ public class TripDto {
                 "    1\n" +
                 "  ]")
         private List<Long> planIdList = new ArrayList<>(); //만약 여러개의 plan을 한번에 삭제하려고 할 때 필요
+
     }
 
     @Getter
@@ -78,6 +84,7 @@ public class TripDto {
     @NoArgsConstructor
     @Builder
     public static class TripPatchDto {
+
         @Schema(description = "trip id", example = "1")
         @NotNull(message = "tripId를 입력해주세요.")
         private Long tripId;
@@ -104,6 +111,7 @@ public class TripDto {
                 "    1\n" +
                 "  ]")
         private List<Long> planIdList = new ArrayList<>(); //만약 여러개의 plan을 한번에 삭제하려고 할 때 필요
+
     }
 
     @Getter

--- a/src/main/java/com/wiztrip/exception/ErrorCode.java
+++ b/src/main/java/com/wiztrip/exception/ErrorCode.java
@@ -22,20 +22,20 @@ public enum ErrorCode {
     INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다"),
     UNAUTHORIZED_MEMBER(UNAUTHORIZED, "존재하지 않는 회원입니다."),
 
-    // 403 FORBIDDEN: 접근 권한이 없는 사용자
+    // 403 FORBIDDEN: 허용되지 않는 접근
     FORBIDDEN_TRIP_USER(FORBIDDEN, "전체 여행 계획 권한이 없는 사용자입니다."),
-    FORBIDDEN_PLAN_USER(FORBIDDEN, "세부 여행 계획 권한이 없는 사용자입니다."),
-    FORBIDDEN_MEMO_USER(FORBIDDEN, "메모 권한이 없는 사용자입니다."),
     FORBIDDEN_REVIEW_USER(FORBIDDEN, "후기글 권한이 없는 사용자입니다."),
     NOT_IN_TRIP_MEMO(FORBIDDEN, "해당 전체 여행 계획에 속한 메모가 아닙니다."),
     NOT_IN_TRIP_PLAN(FORBIDDEN, "해당 전체 여행 계획에 속한 세부 여행 계획이 아닙니다."),
     NOT_IN_TRIP_REVIEW(FORBIDDEN, "해당 전체 여행 계획에 속한 후기글이 아닙니다."),
+    EXPIRED_TRIP_URL(FORBIDDEN, "유효 기간이 만료된 url 입니다."),
 
     // 404 NOT_FOUND: 잘못된 리소스 접근
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 회원 정보를 찾을 수 없습니다."),
     LANDMARK_NOT_FOUND(NOT_FOUND, "해당 여행지 정보를 찾을 수 없습니다."),
     TRIP_NOT_FOUND(NOT_FOUND, "해당 전체 여행 계획을 찾을 수 없습니다."),
+    TRIP_URL_NOT_FOUND(NOT_FOUND, "해당 url을 찾을 수 없습니다."),
     PLAN_NOT_FOUND(NOT_FOUND, "해당 세부 여행 계획을 찾을 수 없습니다."),
     MEMO_NOT_FOUND(NOT_FOUND, "해당 메모를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(NOT_FOUND, "해당 후기글을 찾을 수 없습니다."),

--- a/src/main/java/com/wiztrip/exception/ErrorCode.java
+++ b/src/main/java/com/wiztrip/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(CONFLICT, "이미 존재하는 닉네임입니다."),
     DUPLICATE_LANDMARK_LIKE(CONFLICT, "사용자가 이미 좋아요에 추가한 여행지입니다."),
     NO_LANDMARK_LIKE_EXIST(CONFLICT, "사용자가 좋아요에 추가하지 않은 여행지입니다."),
+    ALREADY_TRIP_FINISHED(CONFLICT, "이미 종료된 전체 여행 계획입니다."),
 
     // 500 INTERNAL SERVER ERROR
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "내부 서버 에러입니다."),

--- a/src/main/java/com/wiztrip/exception/ErrorCode.java
+++ b/src/main/java/com/wiztrip/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     // 403 FORBIDDEN: 허용되지 않는 접근
     FORBIDDEN_TRIP_USER(FORBIDDEN, "전체 여행 계획 권한이 없는 사용자입니다."),
+    FORBIDDEN_TRIP_OWNER(FORBIDDEN, "전체 여행 계획 소유자가 아닙니다."),
     FORBIDDEN_REVIEW_USER(FORBIDDEN, "후기글 권한이 없는 사용자입니다."),
     NOT_IN_TRIP_MEMO(FORBIDDEN, "해당 전체 여행 계획에 속한 메모가 아닙니다."),
     NOT_IN_TRIP_PLAN(FORBIDDEN, "해당 전체 여행 계획에 속한 세부 여행 계획이 아닙니다."),
@@ -41,6 +42,7 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(NOT_FOUND, "해당 후기글을 찾을 수 없습니다."),
     LIKE_NOT_FOUND(NOT_FOUND,"해당 좋아요를 찾을 수 없습니다."),
     IMAGE_NOT_FOUND(NOT_FOUND, "해당 이미지를 찾을 수 없습니다."),
+    USER_NOT_FOUND(NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
 
     // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)
     DUPLICATE_EMAIL(CONFLICT, "이미 존재하는 이메일입니다."),

--- a/src/main/java/com/wiztrip/mapstruct/TripMapper.java
+++ b/src/main/java/com/wiztrip/mapstruct/TripMapper.java
@@ -49,7 +49,8 @@ public abstract class TripMapper {
             @Mapping(target = "memoEntityList", ignore = true),//todo: 나중에 수정해야함!!!!
             @Mapping(target = "reviewEntityList", ignore = true),
             @Mapping(target = "tripUserEntityList", source = "tripPostDto.userIdList", qualifiedByName = "userIdListToTripUserEntityList"),
-            @Mapping(target = "tripUrlEntityList", ignore = true)
+            @Mapping(target = "tripUrlEntityList", ignore = true),
+            @Mapping(target = "finished", ignore = true)
     })
     abstract TripEntity _toEntity(UserEntity owner, TripDto.TripPostDto tripPostDto);
 
@@ -57,7 +58,8 @@ public abstract class TripMapper {
             @Mapping(target = "tripId", source = "id"),
             @Mapping(target = "ownerId", expression = "java(trip.getOwner().getId())"),
             @Mapping(target = "userIdList", expression = "java(trip.getTripUserEntityList().stream().map(o->o.getUser().getId()).toList())"),
-            @Mapping(target = "planIdList", expression = "java(trip.getPlanEntityList().stream().map(o->o.getId()).toList())")
+            @Mapping(target = "planIdList", expression = "java(trip.getPlanEntityList().stream().map(o->o.getId()).toList())"),
+            @Mapping(target = "finished", expression = "java(trip.isFinished())")
     })
     public abstract TripDto.TripResponseDto toResponseDto(TripEntity trip);
 
@@ -86,7 +88,8 @@ public abstract class TripMapper {
             @Mapping(target = "memoEntityList", ignore = true), //todo: 나중에 수정해야함!!!!
             @Mapping(target = "reviewEntityList", ignore = true),
             @Mapping(target = "tripUserEntityList", source = "userIdList", qualifiedByName = "userIdListToTripUserEntityList"),
-            @Mapping(target = "tripUrlEntityList", ignore = true)
+            @Mapping(target = "tripUrlEntityList", ignore = true),
+            @Mapping(target = "finished", ignore = true)
     })
     abstract void _updateFromPatchDto(TripDto.TripPatchDto tripPatchDto, @MappingTarget TripEntity trip);
 

--- a/src/main/java/com/wiztrip/repository/TripRepository.java
+++ b/src/main/java/com/wiztrip/repository/TripRepository.java
@@ -14,4 +14,7 @@ public interface TripRepository extends JpaRepository<TripEntity,Long> {
 
     @Query("select t.id from TripEntity t join TripUserEntity tu on tu.trip.id=t.id where tu.user.id=:userId")
     Page<Long> findAllTripIdByUserId(Long userId, Pageable pageable);
+
+    boolean existsByOwnerIdAndId(Long userId, Long id);
+
 }

--- a/src/main/java/com/wiztrip/repository/TripUrlRepository.java
+++ b/src/main/java/com/wiztrip/repository/TripUrlRepository.java
@@ -1,0 +1,10 @@
+package com.wiztrip.repository;
+
+import com.wiztrip.domain.TripUrlEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TripUrlRepository extends JpaRepository<TripUrlEntity, Long> {
+    boolean existsByUrl(String Url);
+}

--- a/src/main/java/com/wiztrip/repository/TripUserRepository.java
+++ b/src/main/java/com/wiztrip/repository/TripUserRepository.java
@@ -1,10 +1,14 @@
 package com.wiztrip.repository;
 
 import com.wiztrip.domain.TripUserEntity;
+import com.wiztrip.domain.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface TripUserRepository extends JpaRepository<TripUserEntity,Long> {
     boolean existsByUserIdAndTripId(Long userId, Long tripId);
+    List<TripUserEntity> findByUser(UserEntity user);
 }

--- a/src/main/java/com/wiztrip/service/TripService.java
+++ b/src/main/java/com/wiztrip/service/TripService.java
@@ -2,7 +2,9 @@ package com.wiztrip.service;
 
 import com.wiztrip.domain.TripEntity;
 import com.wiztrip.domain.TripUrlEntity;
+import com.wiztrip.domain.TripUserEntity;
 import com.wiztrip.domain.UserEntity;
+import com.wiztrip.dto.ListDto;
 import com.wiztrip.dto.TripDto;
 import com.wiztrip.exception.CustomException;
 import com.wiztrip.exception.ErrorCode;
@@ -17,6 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -54,6 +58,15 @@ public class TripService {
 
     public Page<TripDto.TripResponseDto> getTripDetailsPageByUser(UserEntity user, Pageable pageable) {
         return tripRepository.findAllTripByUserId(user.getId(), pageable).map(tripMapper::toResponseDto);
+    }
+
+    public ListDto<TripDto.TripResponseDto> getTripDetailsByUser(UserEntity user) {
+        List<TripUserEntity> tripUserList = tripUserRepository.findByUser(user);
+
+        return new ListDto<>(tripUserList.stream().map(o -> {
+            checkValid(user.getId(), o.getTrip().getId());
+            return tripMapper.toResponseDto(o.getTrip());
+        }).toList());
     }
 
     @Transactional

--- a/src/main/java/com/wiztrip/service/TripService.java
+++ b/src/main/java/com/wiztrip/service/TripService.java
@@ -1,19 +1,23 @@
 package com.wiztrip.service;
 
 import com.wiztrip.domain.TripEntity;
+import com.wiztrip.domain.TripUrlEntity;
 import com.wiztrip.domain.UserEntity;
 import com.wiztrip.dto.TripDto;
 import com.wiztrip.exception.CustomException;
 import com.wiztrip.exception.ErrorCode;
 import com.wiztrip.mapstruct.TripMapper;
 import com.wiztrip.repository.TripRepository;
+import com.wiztrip.repository.TripUrlRepository;
 import com.wiztrip.repository.TripUserRepository;
+import com.wiztrip.tool.redis.RedisTool;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,10 @@ public class TripService {
     private final TripRepository tripRepository;
 
     private final TripUserRepository tripUserRepository;
+
+    private final TripUrlRepository tripUrlRepository;
+
+    private final RedisTool redisTool;
 
     @Transactional
     public TripDto.TripResponseDto createTrip(UserEntity user, TripDto.TripPostDto tripPostDto) {
@@ -62,6 +70,59 @@ public class TripService {
         checkValid(user.getId(),tripId);
         tripRepository.deleteById(tripId);
         return "tripId: " + tripId + " 삭제 완료";
+    }
+
+    @Transactional
+    public TripDto.TripUrlResponseDto createTripUrl(UserEntity user, Long tripId) {
+
+        TripEntity trip = tripRepository.findById(tripId).orElseThrow(() -> new CustomException(ErrorCode.TRIP_NOT_FOUND));
+        checkValid(user.getId(),tripId);
+
+        String url = redisTool.getValues(trip.getId().toString());
+
+        // redis 내에 이전에 생성한 url이 없는 경우, 새로 생성
+        if("false".equals(url)) {
+
+            // 랜덤 문자열 생성 (10개 문자)
+            do {
+                url = java.util.UUID.randomUUID().toString().replaceAll("-", "").toUpperCase().substring(0, 10);
+            } while (tripUrlRepository.existsByUrl(url));
+
+            // redis는 key를 통해 value를 찾는 것을 직접적으로 지원하지 않기 때문에 역방향인 경우에서도 저장
+            redisTool.setValues(trip.getId().toString(), url);
+            redisTool.setValues(url, trip.getId().toString());
+
+            // 유효 기간: 1주일 (7 * 24 * 60 * 60 * 1000)
+            redisTool.expireValues(trip.getId().toString(), 7 * 24 * 60 * 60 * 1000);
+            redisTool.expireValues(url, 7 * 24 * 60 * 60 * 1000);
+
+            TripUrlEntity tripUrlEntity = new TripUrlEntity();
+            tripUrlEntity.setTrip(trip);
+            tripUrlEntity.setUrl(url);
+            tripUrlRepository.save(tripUrlEntity);
+
+        }
+
+        return tripMapper.toUrlResponseDto(trip);
+    }
+
+    @Transactional
+    public TripDto.TripIdResponseDto getTripUrl(String url) {
+
+        String stringTripId = redisTool.getValues(url);
+
+        if ("false".equals(stringTripId)) {
+            if (tripUrlRepository.existsByUrl(url)) {
+                throw new CustomException(ErrorCode.EXPIRED_TRIP_URL);
+            } else {
+                throw new CustomException(ErrorCode.TRIP_URL_NOT_FOUND);
+            }
+        }
+
+        Long tripId = Long.parseLong(stringTripId);
+        TripEntity trip = tripRepository.findById(tripId).orElseThrow(() -> new CustomException(ErrorCode.TRIP_NOT_FOUND));
+
+        return tripMapper.toTripIdResponseDto(trip);
     }
 
     private void checkValid(Long userId, Long tripId) {


### PR DESCRIPTION
사용자가 공유할 수 있는 url을 생성하는 기능을 구현했습니다.
해당 기능은 1주일 동안 접근 가능하며, 총 10글자로 랜덤하게 생성합니다.
본래 entity를 따로 만들지 않고, redis만 사용해서 구현하려고 했으나, redis는 유효 기간이 만료되면 해당 값을 삭제하기에 유효 기간이 만료된 url과의 중복을 염려해 tripUrlEntity를 생성하였습니다. 
또한, redis는 key를 통해 value를 찾는 것을 직접적으로 지원하지 않으므로 key-value를 반대로 해서 총 두 번 저장하게 구현했습니다.

그 외,  지난번 회의에서 Trip 내에 수정이 필요하거나 추가해야 할 부분을 추가했습니다. 목록은 아래와 같습니다.

1. Trip 삭제 시, Owner(Trip 생성자)만 삭제할 수 있도록 하기
- 해당 내용을 구현하기 위해 TripEntity내에 owner 필드를 추가했습니다.

2. 페이징 없는 Trip 조회 API 생성하기

3. Plan name 삭제하기

4. Trip 종료 기능 추가하기
- 해당 내용을 구현하기 위해 TripEntity내에 finished 필드를 추가했습니다.
tripId를 통해 종료하면, 해당 값을 true로 변경합니다.
Trip 종료 기능도 삭제 기능처럼 우선 Owner만 종료할 수 있도록 만들었고, 종료 후에는 Trip을 더 이상 수정할 수 없게 구현했습니다. 해당 부분은 논의 후, 수정이 필요하면 수정해놓겠습니다. 또한, Trip의 종료 후에 Plan과 Memo 역시 더 이상 생성, 수정, 삭제할 수 없게 해야 할지도 논의가 필요하다고 생각합니다. 이 부분 또한, Trip 종료 후 Review 작성이 가능하게 하는 것과 함께 추후 수정해놓겠습니다.

혹시 수정 사항이 있다면 말씀해주세요.
감사합니다!