### PR TITLE
signup 수정

### DIFF
--- a/src/main/java/com/wiztrip/repository/UserRepository.java
+++ b/src/main/java/com/wiztrip/repository/UserRepository.java
@@ -11,6 +11,8 @@ public interface UserRepository extends JpaRepository<UserEntity,Long> {
 
     Optional<UserEntity> findByUsername(String username);
 
+    Optional<UserEntity> findByEmail(String email);
+
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/wiztrip/service/UserService.java
+++ b/src/main/java/com/wiztrip/service/UserService.java
@@ -86,6 +86,18 @@ public class UserService {
             throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
         }
 
+        // 이메일 중복 처리
+        userRepository.findByEmail(registrationDto.getEmail())
+                .ifPresent(u -> {
+                    throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+                });
+
+        // 유저네임 중복 처리
+        userRepository.findByUsername(registrationDto.getUsername())
+                .ifPresent(u -> {
+                    throw new IllegalArgumentException("이미 존재하는 유저네임입니다.");
+                });
+
         UserEntity newUser = new UserEntity();
         newUser.setUsername(registrationDto.getUsername());
         newUser.setEmail(registrationDto.getEmail());


### PR DESCRIPTION
 기존에 username 과 이메일이 같아서 생긴 문제 
ex )
kyung@naver.com이랑
kyunh@gmail.com 일 경우에 username이 같아져서 회원가입이 안되는 문제를 해결하기 위해 
username과 email 을 분리하여 해결하도록 구현하였습니다. 

확인해보시고 피드백있으시면 부탁드립니다!

